### PR TITLE
Verbs refactor

### DIFF
--- a/env_setup.sh
+++ b/env_setup.sh
@@ -1,7 +1,10 @@
 # set up directory basename
-export BASE_DIR=
+export BASE_DIR="/home/sandra/py/btai/czech"
 
 # export subdirectories
 export PYTHON_PATH=$PYTHON_PATH:$BASE_DIR"/src"
 export PYTHON_PATH=$PYTHON_PATH:$BASE_DIR"/data"
 export PYTHON_PATH=$PYTHON_PATH:$BASE_DIR"/test"
+
+# alias for test command(s)
+alias tests=". $BASE_DIR/test.sh"

--- a/src/conjugator_utils.py
+++ b/src/conjugator_utils.py
@@ -1,7 +1,7 @@
 # functions, classes, and other utilities for the main conjugator
 import re
-import verbs as v
-import verb_utils as vutils
+import src.verbs as v
+import src.verb_utils as vutils
 
 # regex patterns
 

--- a/src/verb_utils.py
+++ b/src/verb_utils.py
@@ -2,7 +2,7 @@
 
 import re
 
-# regex patterns -> TODO: make these public? static members
+# regex patterns
 short_vowel = "[aeiouy]"
 long_vowel = "[áéíóúůý]|(ou)"
 soft_vowel = "[ěií]"
@@ -13,13 +13,13 @@ digraph = "(ch)|(st)|(št)|(ct)|(čt)"
 consonant = hard_consonant + "|" + neutral_consonant + "|" + soft_consonant + "|" + digraph
 vowel = short_vowel + "|" + long_vowel + "|" + soft_vowel
 
-# dictionaries for letter mappings -> TODO: make these private static members
+# dictionaries for letter mappings
 hard_to_soft = {"k":"c", "d":"ď", "g":"z", "h":"z", "n":"ň", "r":"ř", "ch":"š", "t":"ť"}
 soft_to_hard = {"c":"k", "ď":"d","z":"h", "ň":"n", "ř":"r", "š":"ch", "ť":"t"}
 long_to_short = {"á":"a", "é":"e", "í":"i", "ů":"o", "ou":"u", "ý":"y"}
 short_to_long = {"a":"á", "e":"é", "i":"í", "o":"ů", "u":"ou", "y":"ý"}
 
-# helper functions -> TODO: make these private members
+# helper functions
 def italics(string):
 	return "\x1B[3m" + string + "\x1B[23m"
 

--- a/src/verb_utils.py
+++ b/src/verb_utils.py
@@ -4,19 +4,27 @@ import re
 
 # regex patterns
 short_vowel = "[aeiouy]"
-long_vowel = "[áéíóúůý]|(ou)"
+long_vowel = "(ou)|[áéíóúůý]"
 soft_vowel = "[ěií]"
-hard_consonant = "[dghknrst]"
+hard_consonant_non_syllabic = "dghknst"
+hard_consonant = "[" + hard_consonant_non_syllabic + "r]"
 neutral_consonant = "[bmpvfqwx]"
-soft_consonant = "[cčďjlňřšťzž]"
+soft_consonant_non_syllabic = "cčďjňřšťzž"
+soft_consonant = "[" + soft_consonant_non_syllabic + "l]"
+syllabic_consonant = "[rl]" # not including m/n since those are RARE
 digraph = "(ch)|(st)|(št)|(ct)|(čt)"
-consonant = hard_consonant + "|" + neutral_consonant + "|" + soft_consonant + "|" + digraph
-vowel = short_vowel + "|" + long_vowel + "|" + soft_vowel
+consonant = hard_consonant + "|" + neutral_consonant + "|" + soft_consonant
+consonant_non_syllabic = digraph + "|" + neutral_consonant + "|[" + soft_consonant_non_syllabic + "]|[" + hard_consonant_non_syllabic + "]"
+consonant_or_digraph = digraph + "|" + consonant
+vowel = long_vowel + "|" + short_vowel + "|" + soft_vowel
+phoneme = "(" + consonant_or_digraph + "|" + vowel + ")"
+cluster = r"(" + consonant_non_syllabic + "){3,5}"
+
 
 # dictionaries for letter mappings
 hard_to_soft = {"k":"c", "d":"ď", "g":"z", "h":"z", "n":"ň", "r":"ř", "ch":"š", "t":"ť"}
 soft_to_hard = {"c":"k", "ď":"d","z":"h", "ň":"n", "ř":"r", "š":"ch", "ť":"t"}
-long_to_short = {"á":"a", "é":"e", "í":"i", "ů":"o", "ou":"u", "ý":"y"}
+long_to_short = {"á":"a", "é":"e", "í":"i", "ů":"o", "ou":"u", "ý":"y", "ú" : "u"}
 short_to_long = {"a":"á", "e":"é", "i":"í", "o":"ů", "u":"ou", "y":"ý"}
 
 # helper functions
@@ -30,6 +38,8 @@ def get_val_from_dict(d, key):
 # functions to change specific letters/digraphs
 def get_short_vowel(long_vowel):
 	'''retrieves the corresponding short vowel of <long_vowel>'''
+	# FIXME: there is ambiguity from key 'u' since it can lead to either long ou or ú. for now it is ou->u only.
+	# ú is only present at the beginning of words
 	return get_val_from_dict(long_to_short, long_vowel)
 
 def get_long_vowel(short_vowel):
@@ -39,6 +49,7 @@ def get_long_vowel(short_vowel):
 def get_hard_consonant(soft_consonant):
 	'''retrieves the corresponding hard consonant of <soft_consonant>'''
 	# FIXME: there is ambiguity from key 'z' since it can lead to either hard g or h. for now it is z->h only.
+	# g is mostly in foreign words/loanwords anyway
 	return get_val_from_dict(soft_to_hard, soft_consonant)
 
 def get_soft_consonant(hard_consonant):
@@ -53,6 +64,10 @@ def isconsonant(letter):
 	'''determines if <letter> is a consonant'''
 	return re.search(consonant, letter) != None
 
+def issyllabic(letter):
+	'''dteermines if <letter> is a syllabic consonant'''
+	return re.search(syllabic_consonant, letter) != None
+
 def get_vowel(stem):
 	'''returns the contained vowels in string <stem> as a list->string'''
 	return str(''.join([letter for letter in stem if isvowel(letter)]))
@@ -66,37 +81,50 @@ def contains_vowel(string):
 	#return re.search("(" + vowel + ")", string) != None
 	return get_vowel(string) != ""
 
+# regex-conversion mappings
+regex_conversion = {"soft" : (soft_consonant, get_hard_consonant), "hard" : ("(ch)|" + hard_consonant, get_soft_consonant),
+					"short" : (short_vowel, get_long_vowel), "long" : (long_vowel, get_short_vowel) }
+def get_pattern_function(pattern_type):
+	''' Returns corresponding regex pattern and conversion function as a tuple'''
+	ret = get_val_from_dict(regex_conversion, pattern_type)
+	return ret if ret != pattern_type else ("^$", None)
+
+# BUG: converts 2nd-to last and so forth if others don't prior match pattern.
+def convert_last_match(word, pattern_type):
+	'''replaces last occurring match of <pattern_type> in <word> with converted value based from <pattern_type>'''
+	ret = word
+	(pattern, conversion) = get_pattern_function(pattern_type)
+
+	# separate into phonemes
+	phonemes  = [match[0] for match in re.findall(phoneme, word)]
+
+	# find last occurrence of the pattern within phonemes to substitute
+	phonemes.reverse()
+	match = re.search(pattern, "".join(phonemes))
+	if match is not None:
+		match = match[0]
+		if match in phonemes:
+			idx = phonemes.index(match) 
+			phonemes[idx] = conversion(match)
+			phonemes.reverse()
+			ret = "".join(phonemes)
+	return ret
+						  
 def lengthen(stem):
 	'''lengthens short vowel in <stem>'''
-	# FIXME: this can be improved to not only work for vowel-final strings.
-	# consonants at the end of the word
-	# more than one vowel...
-	vowel = get_vowel(stem)
-	stem_no_vowel = stem[:-len(vowel)] if len(vowel) > 0 else stem[:len(stem)]
-	return stem_no_vowel + get_long_vowel(vowel)
+	return convert_last_match(stem, "short")
 
 def shorten(stem):
 	'''shortens long vowel in <stem>'''
-	# FIXME: this can be improved to not only work for vowel-final strings.
-	# consonants at the end of the word
-	# more than one vowel...
-	vowel = get_vowel(stem)
-	stem_no_vowel = stem[:-len(vowel)] if len(vowel) > 0 else stem[:len(stem)]
-	return stem_no_vowel + get_short_vowel(vowel)
+	return convert_last_match(stem, "long")
 
 def soften(stem):
 	'''softens the final hard consonant in <stem>'''
-	# FIXME: this can be improved upon
-	consonant = get_consonant(stem)
-	stem_no_consonant = stem[:-len(consonant)] if len(consonant) > 0 else stem[:len(stem)]
-	return stem_no_consonant + get_soft_consonant(consonant)
+	return convert_last_match(stem, "hard")
 
 def harden(stem):
 	'''hardens the final soft consonant in <stem>'''
-	# FIXME: this can be improved upon
-	consonant = get_consonant(stem)
-	stem_no_consonant = stem[:-len(consonant)] if len(consonant) > 0 else stem[:len(stem)]
-	return stem_no_consonant + get_hard_consonant(consonant)
+	return convert_last_match(stem, "soft")
 
 def fix_spelling(word):
 	'''fixes spelling of soft consonants ď, ť, and ň  aside soft vowels i, í, and ě in <word>'''
@@ -113,4 +141,71 @@ def fix_spelling(word):
 			word = re.sub(match, consonant + vowel, word)
 	return word
 
+# helper class
+class Syllables:
+	def __init__(self, word):
+		# separate into phonemes
+		phonemes  = [match[0] for match in re.findall(phoneme, word)]
 
+		# construct the syllables from the given word
+		self.syllable_list = [] # tuples of (syllable, has_syllabic)
+		self._construct_syllable_list(phonemes)
+		
+	def _construct_syllable_list(self, phonemes):
+		syllable_string = ""
+		has_vowel = False
+		has_syllabic = False
+		for phoneme in phonemes:
+			if isvowel(phoneme):
+				if has_vowel:
+					# syllable is complete
+					self.syllable_list.append((syllable_string, has_syllabic))
+					has_vowel = False
+					has_syllabic = False
+					syllable_string = ""
+				syllable_string += phoneme
+				has_vowel = True
+				has_syllabic = False
+			elif issyllabic(phoneme):
+				has_syllabic = not has_vowel
+				syllable_string += phoneme
+			elif isconsonant(phoneme):
+				if has_vowel or has_syllabic:
+					# syllable is complete
+					self.syllable_list.append((syllable_string, has_syllabic))
+					has_vowel = False
+					has_syllabic = False
+					syllable_string = ""
+				syllable_string += phoneme
+
+		# there may be trailing phonemes
+		if len(syllable_string) > 0:
+			# put trailing consonants onto current syllable
+			if not has_vowel and not has_syllabic and len(self.syllable_list) > 0:
+				new_syllable = (self.syllable_list[-1][0] + syllable_string, self.syllable_list[-1][1])
+				self.syllable_list[-1] = new_syllable
+			# otherwise make as new syllable
+			else:
+				has_syllabic = False
+				self.syllable_list.append((syllable_string, has_syllabic))
+
+	# utilities	
+	def _get_syllable_at(self, idx):
+		valid_cond = (idx < 0 and abs(idx) <= len(self.syllable_list)) or (idx < len(self.syllable_list))
+		return self.syllable_list[idx] if valid_cond else ("", False)
+
+	def inspect_syllable(self, idx):
+		'''returns syllable string at indicated <idx>'''
+		return self._get_syllable_at(idx)[0]
+	
+	def is_syllabic(self, idx):
+		'''returns is_syllabic state at indicated <idx>'''
+		return self._get_syllable_at(idx)[1]
+
+	def contains_cluster(self, idx):
+		'''determines if syllable at <idx> contains a consonant cluster'''
+		return re.search(cluster, self.inspect_syllable(idx))
+	
+	def contains_vowel(self, idx):
+		'''determines if syllable at <idx> contains any vowels'''
+		return contains_vowel(self.inspect_syllable(idx))

--- a/src/verbs.py
+++ b/src/verbs.py
@@ -8,11 +8,6 @@
 # all verbs 2 strings during init: infinitive and ending
 # optional flags can also be passed in: is_perfective (bool) , is_motion (tuple)
 
-
-# TODO:
-# 1. remove the pretty table elements entirely
-		# requires refactoring all the verb classes
-
 import src.verb_utils as vutils
 #import verb_utils as vutils
 import re
@@ -239,81 +234,89 @@ class Class1_at(Class1):
 	def kind(self):
 		print("Class I verb subclass, specific to regular -at/-át verbs")
 
-# class Class2(Verb):
-# 	# class specific endings
-# 	_present_endings = ["i/u", "eš", "e", "eme", "ete", "í"]
-# 	def __init__(self, infinitive = "", ending = ""):
-# 		Verb.__init__(self, infinitive, ending)
+class Class2(Verb):
+	# class specific endings
+	_present_endings = ["i/u", "eš", "e", "eme", "ete", "í"]
+	_tense_to_ending = [ _present_endings, Verb._participle_endings, Verb._empty, Verb._imperative_endings, Verb._participle_endings]
+	_tense_to_auxiliary = [ Verb._empty, Verb._past_auxiliary, Verb._future_auxiliary, Verb._empty, Verb._conditional_auxiliary]
+	def __init__(self, infinitive = "", ending = "", is_perfective = False, is_motion = (False, "")):
+		super().__init__(infinitive, ending, is_perfective, is_motion)
 
-# 	def kind(self):
-# 		print("Class II verb, conjugates according to -ít/-ýt/-ovat paradigm")
+		# update endings
+		self._tense_to_ending[Tense.PRESENT] = self._present_endings
 
-# 	def _apply_chtit_correction(self, tense_idx, person_idx):
-# 		if ((tense_idx == Tense.PRESENT or tense_idx == len(Tense))):
-# 			if (person_idx == Person.FIRST_SG or person_idx == len(Person)):
-# 				self._conjugation_table[Tense.PRESENT][Person.FIRST_SG] = "chci"
-# 			if (person_idx == Person.THIRD_PL or person_idx == len(Person)):
-# 				self._conjugation_table[Tense.PRESENT][Person.THIRD_PL] = "chtějí"
-# 		return
+	def kind(self):
+		print("Class II verb, conjugates according to -ít/-ýt/-ovat paradigm")
+
+	def _apply_chtit_correction(self, tense_idx, person_idx):
+		if ((tense_idx == Tense.PRESENT or tense_idx == len(Tense))):
+			if (person_idx == Person.FIRST_SG or person_idx == len(Person)):
+				entry = self._conjugation_table[Tense.PRESENT][Person.FIRST_SG]
+				entry = entry[:-8] + "chci"
+				self._conjugation_table[Tense.PRESENT][Person.FIRST_SG] = entry
+			if (person_idx == Person.THIRD_PL or person_idx == len(Person)):
+				entry = self._conjugation_table[Tense.PRESENT][Person.THIRD_PL]
+				entry = entry[:-6] + "chtějí"
+				self._conjugation_table[Tense.PRESENT][Person.THIRD_PL] = entry
+		return
 		
-# 	def conjugate(self, tense_idx, person_idx):
-# 		# if verb is chtít, ALWAYS overwrite/correct it
-# 		Verb.conjugate(self, tense_idx, person_idx)
-# 		if re.search("chtít$", self.infinitive):
-# 			self._apply_chtit_correction(self, tense_idx, person_idx)
+	def conjugate(self, tense_idx = len(Tense), person_idx = len(Person)):
+		# if verb is chtít, ALWAYS overwrite/correct it
+		Verb.conjugate(self, tense_idx, person_idx)
+		if re.search("chtít$", self.infinitive):
+			self._apply_chtit_correction(tense_idx, person_idx)
 
 
-# class Class2_ityt(Class2):
-# 	def __init__(self, infinitive, ending):
-# 		_thematic_vowel = "i" if ending.startswith("í") else "y"
-# 		self.infinitive = infinitive
-# 		self.ending = ending
-# 		self.stem = infinitive[:-len(ending)]
-# 		self.present_stem = self.stem + _thematic_vowel + "j"
-# 		self.past_stem = self.stem + _thematic_vowel + "l"
-# 		self.imperative_stem = self.present_stem
-# 		#self.passive_stem = self.stem + _thematic_vowel + "t"
+class Class2_ityt(Class2):
+	def __init__(self, infinitive, ending, is_perfective = False, is_motion = (False, "")):
+		super().__init__(infinitive, ending, is_perfective, is_motion)
+		_thematic_vowel = "i" if ending.startswith("í") else "y"
+		self.infinitive = infinitive
+		self.ending = ending
+		self.stem = infinitive[:-len(ending)]
+		self.present_stem = self.stem + _thematic_vowel + "j"
+		self.past_stem = self.stem + _thematic_vowel + "l"
+		self.imperative_stem = self.present_stem
+		#self.passive_stem = self.stem + _thematic_vowel + "t"
 
-# 	def kind(self):
-# 		print("Class II verb subclass, specific to -ít/-ýt verbs")
+		# update stems
+		future_stem = self.infinitive[2:] if self.infinitive[:2] == "ne" else self.infinitive
+		self._stems = [self.present_stem, self.past_stem, future_stem, self.imperative_stem, self.past_stem ]
 
-# class Class2_ovat(Class2):
-# 	def __init__(self, infinitive, ending):
-# 		self.infinitive = infinitive
-# 		self.ending = ending
-# 		self.stem = infinitive[:-len(ending)]
-# 		self.present_stem = self.stem + "uj"
-# 		self.past_stem = self.stem + "oval"
-# 		self.imperative_stem = self.present_stem
-# 		#self.passive_stem = self.stem + "ován"
+	def kind(self):
+		print("Class II verb subclass, specific to -ít/-ýt verbs")
 
-# 	def kind(self):
-# 		print("Class II verb subclass, specific to -ovat verbs")
+class Class2_ovat(Class2):
+	def __init__(self, infinitive, ending, is_perfective = False, is_motion = (False, "")):
+		super().__init__(infinitive, ending, is_perfective, is_motion)
+		self.infinitive = infinitive
+		self.ending = ending
+		self.stem = infinitive[:-len(ending)]
+		self.present_stem = self.stem + "uj"
+		self.past_stem = self.stem + "oval"
+		self.imperative_stem = self.present_stem
+		#self.passive_stem = self.stem + "ován"
 
-# class Class3(Verb):
-# 	def __init__(self, infinitive = "", ending = ""):
-# 		Verb.__init__(self, infinitive, ending)
+		# update stems
+		future_stem = self.infinitive[2:] if self.infinitive[:2] == "ne" else self.infinitive
+		self._stems = [self.present_stem, self.past_stem, future_stem, self.imperative_stem, self.past_stem ]
 
-# 	def kind(self):
-# 		print("Class III verb, conjugates according to -it/et/-ět paradigm")
+	def kind(self):
+		print("Class II verb subclass, specific to -ovat verbs")
 
-# 	def _conjugate_present(self):
-# 		# TODO: move the regex to vutils, contains_stem()
-# 		plural_third_ending = "ědí" if re.search("jíst$|sníst$|vědět$", self._infinitive) else "í"
-# 		plural_third = self._present_stem + plural_third_ending
-# 		present_tense = PrettyTable(self._present_header)
-# 		present_conjugation = PrettyTable(self._conjugation_headers)
-# 		present_conjugation.add_row(["1.", self._present_stem + "ím", self._present_stem + "íme"])
-# 		present_conjugation.add_row(["2.", self._present_stem + "íš", self._present_stem + "íte"])
-# 		present_conjugation.add_row(["3.", self._present_stem + "í", plural_third])
-# 		present_tense.add_row([present_conjugation])
-# 		return present_tense
+class Class3(Verb):
+	# class specific endings
+	_present_endings = ["ím", "íš", "í", "íme", "íte", "í"]
+	_tense_to_ending = [ _present_endings, Verb._participle_endings, Verb._empty, Verb._imperative_endings, Verb._participle_endings]
+	_tense_to_auxiliary = [ Verb._empty, Verb._past_auxiliary, Verb._future_auxiliary, Verb._empty, Verb._conditional_auxiliary]
+	def __init__(self, infinitive = "", ending = "", is_perfective = False, is_motion = (False, "")):
+		super().__init__(infinitive, ending, is_perfective, is_motion)
 
-# 	def conjugate(self):
-# 		print(self._conjugate_present())
-# 		print(Verb._conjugate_imperative(self))
-# 		print(Verb._conjugate_past(self))
-# 		print(Verb._conjugate_conditional(self))
+		# update endings
+		self._tense_to_ending[Tense.PRESENT] = self._present_endings
+
+	def kind(self):
+		print("Class III verb, conjugates according to -it/et/-ět paradigm")
 
 # class Class3_itet(Class3):
 # 	def __init__(self, infinitive, ending):
@@ -370,88 +373,99 @@ class Class1_at(Class1):
 # 	def kind(self):
 # 		print("Class III subclass, specific to regular -it/-et/-ět verbs")
 
-# class Class4(Verb):
-# 	def __init__(self, infinitive = "", ending = ""):
-# 		Verb.__init__(self, infinitive, ending)
+class Class4(Verb):
+	# class specific endings
+	_present_endings = ["u", "eš", "e", "eme", "ete", "ou"]
+	_tense_to_ending = [ _present_endings, Verb._participle_endings, Verb._empty, Verb._imperative_endings, Verb._participle_endings]
+	_tense_to_auxiliary = [ Verb._empty, Verb._past_auxiliary, Verb._future_auxiliary, Verb._empty, Verb._conditional_auxiliary]
+	def __init__(self, infinitive, ending, is_perfective = False, is_motion = (False, "")):
+		super().__init__(infinitive, ending, is_perfective, is_motion)
 
-# 	def kind(self):
-# 		print("Class IV verb, conjugates according to -nout/-st/-ct/-zt paradigm")
+	def kind(self):
+		print("Class IV verb, conjugates according to -nout/-st/-ct/-zt paradigm")
 
-# 	def _conjugate_present(self):
-# 		present_tense = PrettyTable(self._present_header)
-# 		present_conjugation = PrettyTable(self._conjugation_headers)
-# 		present_conjugation.add_row(["1.", self._present_stem + "u", self._present_stem + "eme"])
-# 		present_conjugation.add_row(["2.", self._present_stem + "eš", self._present_stem + "ete"])
-# 		present_conjugation.add_row(["3.", self._present_stem + "e", self._present_stem + "ou"])
-# 		present_tense.add_row([present_conjugation])
-# 		return present_tense
+class Class4_nout(Class4):
+	def __init__(self, infinitive, ending, is_perfective = False, is_motion = (False, "")):
+		super().__init__(infinitive, ending, is_perfective, is_motion)
+		self.infinitive = infinitive
+		self.ending = ending
+		self.stem = infinitive[:-len(ending)]
+		self.present_stem = self.stem + "n"
+		self.imperative_stem = self.stem + "ň" 
+		if not vutils.isvowel(self.stem[-1]):
+			self.imperative_stem = self.stem + "ni"
+		self.past_stem = self.stem + "nul"
+		if not (vutils.isvowel(self.past_stem[0]) or not vutils.contains_vowel(self.past_stem[:-len(self.ending)])):
+			self.past_stem = self.stem + "l" # ie "tiskl"
+			
+		# update stems
+		future_stem = self.infinitive[2:] if self.infinitive[:2] == "ne" else self.infinitive
+		self._stems = [self.present_stem, self.past_stem, future_stem, self.imperative_stem, self.past_stem ]
 
-# 	def conjugate(self):
-# 		print(self._conjugate_present())
-# 		print(Verb._conjugate_imperative(self))
-# 		print(Verb._conjugate_past(self))
-# 		print(Verb._conjugate_conditional(self))
+		#self._passive_stem = self._stem + "nut"
 
-# class Class4_nout(Class4):
-# 	def __init__(self, infinitive, ending):
-# 		self._infinitive = infinitive
-# 		self._ending = ending
-# 		self._stem = infinitive[:-len(ending)]
-# 		self._present_stem = self._stem + "n"
-# 		self._imperative_stem = self._stem + "ň" if vutils.isvowel(self._stem[-1]) else self._stem + "ni"
-# 		self._past_stem = self._stem
-# 		if vutils.isvowel(self._past_stem[0]) or  not vutils.contains_vowel(self._past_stem[:-len(self._ending)]):
-# 			self._past_stem += "nul"
-# 		else:
-# 			self._past_stem += "l"
-# 		#self._passive_stem = self._stem + "nut"
+	def kind(self):
+		print("Class IV verb subclass, specific for -nout verbs")
 
-# 		#self._past_stem_variant = self._stem[:-1] + "něl"
-# 		#self._passive_stem_variant = self._stem[:-1] + "něn"
+	def conjugate(self, tense_idx = len(Tense), person_idx = len(Person)):
+		Verb.conjugate(self, tense_idx, person_idx)
 
-# 	def kind(self):
-# 		print("Class IV verb subclass, specific for -nout verbs")
+		# apply imperative corrections if stem is -ni
+		if self.imperative_stem[-2:] == "ni":
+			self._conjugation_table[Tense.IMPERATIVE][Person.FIRST_PL] = self.imperative_stem[:-1] + "ěme"
+			self._conjugation_table[Tense.IMPERATIVE][Person.SECOND_PL] = self.imperative_stem[:-1] + "ěte"
 
-# 	def stems(self):
-# 		Verb.stems(self)
-# 		#print("past stem variant: ", self._past_stem_variant)
-# 		#print("passive stem variant: ", self._passive_stem_variant)
 
-# class Class4_st(Class4):
-# 	def __init__(self, infinitive, ending):
-# 		self._infinitive = infinitive
-# 		self._ending = ending
-# 		self._stem = vutils.shorten(infinitive[:-len(ending)])
-# 		self._present_stem = self._stem + "d"
-# 		self._past_stem = self._present_stem + "l"
-# 		#self._passive_stem = self._present_stem + "en"
-# 		self._imperative_stem = vutils.soften(self._present_stem)
+class Class4_st(Class4):
+	def __init__(self, infinitive, ending, is_perfective = False, is_motion = (False, "")):
+		super().__init__(infinitive, ending, is_perfective, is_motion)
+		self.infinitive = infinitive
+		self.ending = ending
+		self.stem = vutils.shorten(infinitive[:-len(ending)])
+		self.present_stem = self.stem + "d"
+		self.past_stem = self.present_stem + "l"
+		#self.passive_stem = self.present_stem + "en"
+		self.imperative_stem = self.stem + vutils.get_soft_consonant(self.present_stem[-1])
 
-# 	def kind(self):
-# 		print("Class IV verb subclass, specific for -st verbs")
+		# update stems
+		future_stem = self.infinitive[2:] if self.infinitive[:2] == "ne" else self.infinitive
+		self._stems = [self.present_stem, self.past_stem, future_stem, self.imperative_stem, self.past_stem ]
 
-# class Class4_zt(Class4):
-# 	def __init__(self, infinitive, ending):
-# 		self._infinitive = infinitive
-# 		self._ending = ending
-# 		self._stem = vutils.shorten(infinitive[:len(ending)])
-# 		self._present_stem = self._stem + "z"
-# 		self._past_stem = self._present_stem + "l"
-# 		#self._passive_stem = self._present_stem + "en"
-# 		self._imperative_stem = self._present_stem
+	def kind(self):
+		print("Class IV verb subclass, specific for -st verbs")
 
-# 	def kind(self):
-# 		print("Class IV verb subclass, specific to -zt verbs")
+class Class4_zt(Class4):
+	def __init__(self, infinitive, ending, is_perfective = False, is_motion = (False, "")):
+		super().__init__(infinitive, ending, is_perfective, is_motion)
+		self._infinitive = infinitive
+		self.ending = ending
+		self.stem = vutils.shorten(infinitive[:len(ending)])
+		self.present_stem = self.stem + "z"
+		self.past_stem = self.present_stem + "l"
+		#self.passive_stem = self._present_stem + "en"
+		self.imperative_stem = self.present_stem
 
-# class Class4_ct(Class4):
-# 	def __init__(self, infinitive, ending):
-# 		self._infinitive = infinitive
-# 		self._ending = ending
-# 		self._stem = vutils.shorten(infinitive[:-len(ending)])
-# 		self._present_stem = self._stem + "č"
-# 		self._past_stem = self._stem + "kl"
-# 		#self._passive_stem = self._present_stem + "en"
-# 		self._imperative_stem = self._present_stem
+		# update stems
+		future_stem = self.infinitive[2:] if self.infinitive[:2] == "ne" else self.infinitive
+		self._stems = [self.present_stem, self.past_stem, future_stem, self.imperative_stem, self.past_stem ]
 
-# 	def kind(self):
-# 		print("Class IV verb subclass, specific to -ct verbs")
+	def kind(self):
+		print("Class IV verb subclass, specific to -zt verbs")
+
+class Class4_ct(Class4):
+	def __init__(self, infinitive, ending, is_perfective = False, is_motion = (False, "")):
+		super().__init__(infinitive, ending, is_perfective, is_motion)
+		self.infinitive = infinitive
+		self.ending = ending
+		self.stem = vutils.shorten(infinitive[:-len(ending)])
+		self.present_stem = self.stem + "č"
+		self.past_stem = self.stem + "kl"
+		#self.passive_stem = self.present_stem + "en"
+		self.imperative_stem = self.present_stem
+
+		# update stems
+		future_stem = self.infinitive[2:] if self.infinitive[:2] == "ne" else self.infinitive
+		self._stems = [self.present_stem, self.past_stem, future_stem, self.imperative_stem, self.past_stem ]
+
+	def kind(self):
+		print("Class IV verb subclass, specific to -ct verbs")

--- a/test.sh
+++ b/test.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+# script to run the tests and keep you in the same directory where you called this script.
+
+old_dir=`pwd`
+cd $BASE_DIR/test
+pytest test_vutils.py test_verbs.py
+cd $old_dir

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -4,6 +4,6 @@
 # from directory.fileName import className
 
 # conjugator.py not included as that is more or less the 'main' program
-from src.verb_utils import * # TODO: make verb_utils be a class instead of a series of functions
-#from src.verbs import * # Imports Verb classes: base Verb and all derived (a lot)
-#from src.conjugator_utils import * # TODO: make conjugator_utils be a class instead of a series of functions
+from src.verb_utils import *
+from src.verbs import * # Imports Verb classes: base Verb and all derived (a lot)
+from src.conjugator_utils import *

--- a/test/test_verbs.py
+++ b/test/test_verbs.py
@@ -28,8 +28,8 @@ def test_init_non_default():
     assert a.imperative_stem == ""
 
     # conjugation should also be empty
-    for tense in range(v.Tense.NUM_TENSE):
-        for person in range(v.Person.NUM_PERSON):
+    for tense in range(len(v.Tense)):
+        for person in range(len(v.Person)):
             assert a.get_conjugation_at(tense, person) == ""
 
 
@@ -39,38 +39,37 @@ def test_conjugate_present():
     a = v.Verb()
     a.conjugate(v.Tense.PRESENT)
 
-    # including spaces since it's not normally a verb is conjugated with empty strings
-    expected_present= [" ", " ", " ", " ", " ", " "] # present tense is class dependent
-    for person in range(v.Person.NUM_PERSON):
+    expected_present= ["", "", "", "", "", ""] # present tense is class dependent
+    for person in range(len(v.Person)):
         assert expected_present[person] == a.get_conjugation_at(v.Tense.PRESENT, person)
 
     # even with an infinitive should still be empty
     b = v.Verb("foobar", "bar")
     b.conjugate(v.Tense.PRESENT)
-    for person in range(v.Person.NUM_PERSON):
+    for person in range(len(v.Person)):
         assert expected_present[person] == b.get_conjugation_at(v.Tense.PRESENT, person)
 
 def test_conjugate_past():
     # should have the right auxillaries
     a = v.Verb()
     a.conjugate(v.Tense.PAST)
-    expected_past = ["/a jsem", "/a jsi/jseš", "/a/o ", "i/y jsme", "i/y jste", "i/y/a "] # past tense
-    for person in range(v.Person.NUM_PERSON):
+    expected_past = ["/a jsem", "/a jsi/jseš", "/a/o", "i/y jsme", "i/y jste", "i/y/a"] # past tense
+    for person in range(len(v.Person)):
         assert expected_past[person] == a.get_conjugation_at(v.Tense.PAST, person)
 
 
     # auxiliaries should still be correct with non-empty (in this case empty)
     b = v.Verb("foobar", "bar")
     b.conjugate(v.Tense.PAST)
-    for person in range(v.Person.NUM_PERSON):
+    for person in range(len(v.Person)):
         assert expected_past[person] == b.get_conjugation_at(v.Tense.PAST, person)
 
 def test_conjugate_future():
      # should have the right auxillaries
     a = v.Verb()
     a.conjugate(v.Tense.FUTURE)
-    expected_future = ["budu ", "budeš ", "bude ", "budeme ", "budete ", "budou "] # future tense
-    for person in range(v.Person.NUM_PERSON):
+    expected_future = ["budu", "budeš", "bude", "budeme", "budete", "budou"] # future tense
+    for person in range(len(v.Person)):
         assert expected_future[person] == a.get_conjugation_at(v.Tense.FUTURE, person)
 
 
@@ -78,22 +77,22 @@ def test_conjugate_future():
     expected_future = ["budu foobar", "budeš foobar", "bude foobar", "budeme foobar", "budete foobar", "budou foobar"] # future tense
     b = v.Verb("foobar", "bar")
     b.conjugate(v.Tense.FUTURE)
-    for person in range(v.Person.NUM_PERSON):
+    for person in range(len(v.Person)):
         assert expected_future[person] == b.get_conjugation_at(v.Tense.FUTURE, person)
 
 def test_conjugate_imperative():
      # should have the right auxillaries
     a = v.Verb()
     a.conjugate(v.Tense.IMPERATIVE)
-    expected_imperative = ["", " ", "", "me ", "te ", ""] # imperative mood
-    for person in range(v.Person.NUM_PERSON):
+    expected_imperative = ["", "", "", "me", "te", ""] # imperative mood
+    for person in range(len(v.Person)):
         assert expected_imperative[person] == a.get_conjugation_at(v.Tense.IMPERATIVE, person)
 
 
     # should all still be empty-ish
     b = v.Verb("foobar", "bar")
     b.conjugate(v.Tense.IMPERATIVE)
-    for person in range(v.Person.NUM_PERSON):
+    for person in range(len(v.Person)):
         assert expected_imperative[person] == b.get_conjugation_at(v.Tense.IMPERATIVE, person)
 
 def test_conjugate_conditional():
@@ -101,14 +100,14 @@ def test_conjugate_conditional():
     expected_conditional = ["/a bych", "/a bys", "/a/o by", "i/y bychom", "i/y byste", "i/y/a by"]
     a = v.Verb()
     a.conjugate(v.Tense.CONDITIONAL)
-    for person in range(v.Person.NUM_PERSON):
+    for person in range(len(v.Person)):
         assert expected_conditional[person] == a.get_conjugation_at(v.Tense.CONDITIONAL, person)
 
 
     # should all still be empty-ish
     b = v.Verb("foobar", "bar")
     b.conjugate(v.Tense.CONDITIONAL)
-    for person in range(v.Person.NUM_PERSON):
+    for person in range(len(v.Person)):
         assert expected_conditional[person] == b.get_conjugation_at(v.Tense.CONDITIONAL, person)
 
 
@@ -117,102 +116,102 @@ def test_conjugate_first_person_singular():
     # expected conjugations
     # indices (0-4): present, past, future, imperative, conditional
     person = v.Person.FIRST_SG
-    expected_conjugations = [" ", "/a jsem", "budu ", "", "/a bych"]
+    expected_conjugations = ["", "/a jsem", "budu", "", "/a bych"]
 
     a = v.Verb()
     a.conjugate(person_idx = person)
-    for tense in range(v.Tense.NUM_TENSE):
+    for tense in range(len(v.Tense)):
         assert expected_conjugations[tense] == a.get_conjugation_at(tense, person)
 
     b = v.Verb("foobar", "bar")
-    expected_conjugations = [" ", "/a jsem", "budu foobar", "", "/a bych"]
+    expected_conjugations = ["", "/a jsem", "budu foobar", "", "/a bych"]
     b.conjugate(person_idx = person)
-    for tense in range(v.Tense.NUM_TENSE):
+    for tense in range(len(v.Tense)):
         assert expected_conjugations[tense] == b.get_conjugation_at(tense, person)
 
 def test_conjugate_second_person_singular():
     # expected conjugations
     # indices (0-4): present, past, future, imperative, conditional
     person = v.Person.SECOND_SG
-    expected_conjugations = [" ", "/a jsi/jseš", "budeš ", " ", "/a bys"]
+    expected_conjugations = ["", "/a jsi/jseš", "budeš", "", "/a bys"]
 
     a = v.Verb()
     a.conjugate(person_idx = person)
-    for tense in range(v.Tense.NUM_TENSE):
+    for tense in range(len(v.Tense)):
         assert expected_conjugations[tense] == a.get_conjugation_at(tense, person)
 
     b = v.Verb("foobar", "bar")
-    expected_conjugations = [" ", "/a jsi/jseš", "budeš foobar", " ", "/a bys"]
+    expected_conjugations = ["", "/a jsi/jseš", "budeš foobar", "", "/a bys"]
     b.conjugate(person_idx = person)
-    for tense in range(v.Tense.NUM_TENSE):
+    for tense in range(len(v.Tense)):
         assert expected_conjugations[tense] == b.get_conjugation_at(tense, person)
 
 def test_conjugate_third_person_singular():
     # expected conjugations
     # indices (0-4): present, past, future, imperative, conditional
     person = v.Person.THIRD_SG
-    expected_conjugations = [" ", "/a/o ", "bude ", "", "/a/o by"]
+    expected_conjugations = ["", "/a/o", "bude", "", "/a/o by"]
 
     a = v.Verb()
     a.conjugate(person_idx = person)
-    for tense in range(v.Tense.NUM_TENSE):
+    for tense in range(len(v.Tense)):
         assert expected_conjugations[tense] == a.get_conjugation_at(tense, person)
 
     b = v.Verb("foobar", "bar")
-    expected_conjugations = [" ", "/a/o ", "bude foobar", "", "/a/o by"]
+    expected_conjugations = ["", "/a/o", "bude foobar", "", "/a/o by"]
     b.conjugate(person_idx = person)
-    for tense in range(v.Tense.NUM_TENSE):
+    for tense in range(len(v.Tense)):
         assert expected_conjugations[tense] == b.get_conjugation_at(tense, person)
 
 def test_conjugate_first_person_plural():
     # expected conjugations
     # indices (0-4): present, past, future, imperative, conditional
     person = v.Person.FIRST_PL
-    expected_conjugations = [" ", "i/y jsme", "budeme ", "me ", "i/y bychom"]
+    expected_conjugations = ["", "i/y jsme", "budeme", "me", "i/y bychom"]
 
     a = v.Verb()
     a.conjugate(person_idx = person)
-    for tense in range(v.Tense.NUM_TENSE):
+    for tense in range(len(v.Tense)):
         assert expected_conjugations[tense] == a.get_conjugation_at(tense, person)
 
     b = v.Verb("foobar", "bar")
-    expected_conjugations = [" ", "i/y jsme", "budeme foobar", "me ", "i/y bychom"]
+    expected_conjugations = ["", "i/y jsme", "budeme foobar", "me", "i/y bychom"]
     b.conjugate(person_idx = person)
-    for tense in range(v.Tense.NUM_TENSE):
+    for tense in range(len(v.Tense)):
         assert expected_conjugations[tense] == b.get_conjugation_at(tense, person)
 
 def test_conjugate_second_person_plural():
     # expected conjugations
     # indices (0-4): present, past, future, imperative, conditional
     person = v.Person.SECOND_PL
-    expected_conjugations = [" ", "i/y jste", "budete ", "te ", "i/y byste"]
+    expected_conjugations = ["", "i/y jste", "budete", "te", "i/y byste"]
 
     a = v.Verb()
     a.conjugate(person_idx = person)
-    for tense in range(v.Tense.NUM_TENSE):
+    for tense in range(len(v.Tense)):
         assert expected_conjugations[tense] == a.get_conjugation_at(tense, person)
 
     b = v.Verb("foobar", "bar")
-    expected_conjugations = [" ", "i/y jste", "budete foobar", "te ", "i/y byste"]
+    expected_conjugations = ["", "i/y jste", "budete foobar", "te", "i/y byste"]
     b.conjugate(person_idx = person)
-    for tense in range(v.Tense.NUM_TENSE):
+    for tense in range(len(v.Tense)):
         assert expected_conjugations[tense] == b.get_conjugation_at(tense, person)
 
 def test_conjugate_third_person_plural():
     # expected conjugations
     # indices (0-4): present, past, future, imperative, conditional
     person = v.Person.THIRD_PL
-    expected_conjugations = [" ", "i/y/a ", "budou ", "", "i/y/a by"]
+    expected_conjugations = ["", "i/y/a", "budou", "", "i/y/a by"]
 
     a = v.Verb()
     a.conjugate(person_idx = person)
-    for tense in range(v.Tense.NUM_TENSE):
+    for tense in range(len(v.Tense)):
         assert expected_conjugations[tense] == a.get_conjugation_at(tense, person)
 
     b = v.Verb("foobar", "bar")
-    expected_conjugations = [" ", "i/y/a ", "budou foobar", "", "i/y/a by"]
+    expected_conjugations = ["", "i/y/a", "budou foobar", "", "i/y/a by"]
     b.conjugate(person_idx = person)
-    for tense in range(v.Tense.NUM_TENSE):
+    for tense in range(len(v.Tense)):
         assert expected_conjugations[tense] == b.get_conjugation_at(tense, person)
 
 # test all conjugations at once
@@ -221,10 +220,10 @@ def test_conjugate_all():
     # expected conjugations
     # indices (0-4): present, past, future, imperative, conditional
     expected_conjugations = []
-    expected_present= [" ", " ", " ", " ", " ", " "] # present tense is class dependent
-    expected_past = ["/a jsem", "/a jsi/jseš", "/a/o ", "i/y jsme", "i/y jste", "i/y/a "] # past tense
-    expected_future = ["budu ", "budeš ", "bude ", "budeme ", "budete ", "budou "] # future tense
-    expected_imperative = ["", " ", "", "me ", "te ", ""] # imperative mood
+    expected_present= ["", "", "", "", "", ""] # present tense is class dependent
+    expected_past = ["/a jsem", "/a jsi/jseš", "/a/o", "i/y jsme", "i/y jste", "i/y/a"] # past tense
+    expected_future = ["budu", "budeš", "bude", "budeme", "budete", "budou"] # future tense
+    expected_imperative = ["", "", "", "me", "te", ""] # imperative mood
     expected_conditional = ["/a bych", "/a bys", "/a/o by", "i/y bychom", "i/y byste", "i/y/a by"] # (present) conditional mood
 
     # indices (0-4): present, past, future, imperative, conditional
@@ -233,8 +232,8 @@ def test_conjugate_all():
     # conjugate everything
     a = v.Verb()
     a.conjugate() 
-    for tense in range(v.Tense.NUM_TENSE):
-        for person in range(v.Person.NUM_PERSON):
+    for tense in range(len(v.Tense)):
+        for person in range(len(v.Person)):
             assert expected_conjugations[tense][person] == a.get_conjugation_at(tense, person)
 
     # now for a verb with an actual infinitive
@@ -242,8 +241,8 @@ def test_conjugate_all():
     expected_future = ["budu foobar", "budeš foobar", "bude foobar", "budeme foobar", "budete foobar", "budou foobar"]
     expected_conjugations = [expected_present, expected_past, expected_future, expected_imperative, expected_conditional]
     b.conjugate()
-    for tense in range(v.Tense.NUM_TENSE):
-        for person in range(v.Person.NUM_PERSON):
+    for tense in range(len(v.Tense)):
+        for person in range(len(v.Person)):
             assert expected_conjugations[tense][person] == b.get_conjugation_at(tense, person)
 
 # test clear for one tense (future)
@@ -251,11 +250,11 @@ def test_conjugate_table_clear():
     tense = v.Tense.FUTURE
     a = v.Verb()
     a.conjugate()
-    for person in range(v.Person.NUM_PERSON):
+    for person in range(len(v.Person)):
         assert a.get_conjugation_at(tense, person) != ""
 
     a.clear_table()
-    for person in range(v.Person.NUM_PERSON):
+    for person in range(len(v.Person)):
         assert a.get_conjugation_at(tense, person) == ""
 
 ############# BÝT CLASS TESTS ###############
@@ -287,17 +286,17 @@ def test_byt_conjugate():
     # indices (0-4): present, past, future, imperative, conditional
     expected_conjugations = []
     expected_present= ["jsem", "jseš/jsi", "je", "jsme", "jste", "jsou"]
-    expected_past = ["byl/a jsem", "byl/a jsi/jseš", "byl/a/o ", "byli/y jsme", "byli/y jste", "byli/y/a "]
-    expected_future = ["budu ", "budeš ", "bude ", "budeme ", "budete ", "budou "]
-    expected_imperative = ["", "buď ", "", "buďme ", "buďte ", ""]
+    expected_past = ["byl/a jsem", "byl/a jsi/jseš", "byl/a/o", "byli/y jsme", "byli/y jste", "byli/y/a"]
+    expected_future = ["budu", "budeš", "bude", "budeme", "budete", "budou"]
+    expected_imperative = ["", "buď", "", "buďme", "buďte", ""]
     expected_conditional = ["byl/a bych", "byl/a bys", "byl/a/o by", "byli/y bychom", "byli/y byste", "byli/y/a by"]
 
     # indices (0-4): present, past, future, imperative, conditional
     expected_conjugations = [expected_present, expected_past, expected_future, expected_imperative, expected_conditional]
 
     byt.conjugate()
-    for tense in range(v.Tense.NUM_TENSE):
-        for person in range(v.Person.NUM_PERSON):
+    for tense in range(len(v.Tense)):
+        for person in range(len(v.Person)):
             assert expected_conjugations[tense][person] == byt.get_conjugation_at(tense, person)
 
 def test_nebyt_conjugate():
@@ -306,18 +305,137 @@ def test_nebyt_conjugate():
     # indices (0-4): present, past, future, imperative, conditional
     expected_conjugations = []
     expected_present= ["nejsem", "nejseš/jsi", "není", "nejsme", "nejste", "nejsou"]
-    expected_past = ["nebyl/a jsem", "nebyl/a jsi/jseš", "nebyl/a/o ", "nebyli/y jsme", "nebyli/y jste", "nebyli/y/a "]
-    expected_future = ["nebudu ", "nebudeš ", "nebude ", "nebudeme ", "nebudete ", "nebudou "]
-    expected_imperative = ["", "nebuď ", "", "nebuďme ", "nebuďte ", ""]
+    expected_past = ["nebyl/a jsem", "nebyl/a jsi/jseš", "nebyl/a/o", "nebyli/y jsme", "nebyli/y jste", "nebyli/y/a"]
+    expected_future = ["nebudu", "nebudeš", "nebude", "nebudeme", "nebudete", "nebudou"]
+    expected_imperative = ["", "nebuď", "", "nebuďme", "nebuďte", ""]
     expected_conditional = ["nebyl/a bych", "nebyl/a bys", "nebyl/a/o by", "nebyli/y bychom", "nebyli/y byste", "nebyli/y/a by"]
 
     # indices (0-4): present, past, future, imperative, conditional
     expected_conjugations = [expected_present, expected_past, expected_future, expected_imperative, expected_conditional]
 
     nebyt.conjugate()
-    for tense in range(v.Tense.NUM_TENSE):
-        for person in range(v.Person.NUM_PERSON):
+    for tense in range(len(v.Tense)):
+        for person in range(len(v.Person)):
             assert expected_conjugations[tense][person] == nebyt.get_conjugation_at(tense, person)
 
+#### TESTS FOR INIT FLAGS (uses být) ####
+
+# perfective verbs use the present tense to form the future, as they cannot express the present
+# the future conjugations are expected present conjugations
+# the present conjugations are empty strings (there is no conjugation)
+def test_perfective_conjugation():
+    expected_future= ("jsem", "jseš/jsi", "je", "jsme", "jste", "jsou")
+    expected_present = ("", "", "", "", "", "")
+    byt = v.Byt("být", is_perfective = True)
+
+    # stuff from just __init__
+    assert byt._is_negative == False
+    assert v.get_motion(byt._is_motion) == False
+    assert byt._is_perfective == True
+    assert byt._tense_to_auxiliary[v.Tense.FUTURE] == ("", "", "", "", "", "")
+    assert byt._tense_to_ending[v.Tense.FUTURE] == expected_future
+    assert byt._tense_to_ending[v.Tense.PRESENT] == expected_present # because být this gets overwritten
+
+    # now conjugation should reflect this
+    byt.conjugate(tense_idx = v.Tense.FUTURE)
+
+    # future conjugations should be present conjugations
+    for person in range(len(v.Person)):
+        assert expected_future[person] == byt.get_conjugation_at(v.Tense.FUTURE, person)
+
+def test_motion_conjugation():
+    expected_future= ("pojsem", "pojseš/jsi", "poje", "pojsme", "pojste", "pojsou")
+    expected_present = ("jsem", "jseš/jsi", "je", "jsme", "jste", "jsou")
+    byt = v.Byt("být", is_motion = (True, "po"))
+
+    # stuff from just __init__
+    assert byt._is_negative == False
+    assert v.get_motion(byt._is_motion) == True
+    assert byt._is_perfective == False
+    assert byt._present_endings == expected_present
+    assert byt._tense_to_auxiliary[v.Tense.FUTURE] == v.Verb._empty
+    assert byt._tense_to_ending[v.Tense.FUTURE] == expected_present
+
+    # now conjugation should reflect this
+    byt.conjugate(tense_idx = v.Tense.FUTURE)
+    byt.conjugate(tense_idx = v.Tense.PRESENT)
+
+    # future conjugations should be present conjugations
+    for person in range(len(v.Person)):
+        assert expected_future[person] == byt.get_conjugation_at(v.Tense.FUTURE, person)
+
+    # present conjugations should also be present
+    for person in range(len(v.Person)):
+        assert expected_present[person] == byt.get_conjugation_at(v.Tense.PRESENT, person)
+
+######## REGULAR CLASS 1 VERBS #############
+# tests that the right stems are formed and correct conjugations for -at
+def test_class1_at_short_a():
+    a = v.Class1_at("bat", "at")
+
+    # expected conjugations
+    # indices (0-4): present, past, future, imperative, conditional
+    expected_conjugations = []
+    expect_present= ["bám", "báš", "bá", "báme", "báte", "bají"]
+    expected_past = ["bal/a jsem", "bal/a jsi/jseš", "bal/a/o", "bali/y jsme", "bali/y jste", "bali/y/a"]
+    expected_future = ["budu bat", "budeš bat", "bude bat", "budeme bat", "budete bat", "budou bat"]
+    expected_imperative = ["", "bej", "", "bejme", "bejte", ""]
+    expected_conditional = ["bal/a bych", "bal/a bys", "bal/a/o by", "bali/y bychom", "bali/y byste", "bali/y/a by"]
+
+    # from __init__
+    assert a.infinitive == "bat"
+    assert a.ending == "at"
+    assert a.stem == "b"
+    assert a.present_stem == "b"
+    assert a.past_stem == "bal"
+    assert a.imperative_stem == "bej"
+    assert a._is_negative == False
+    assert a._is_perfective == False
+    assert v.get_motion(a._is_motion) == False
+    assert v.get_motion_prefix(a._is_motion) == ""
+
+    # indices (0-4): present, past, future, imperative, conditional
+    expected_conjugations = [expect_present, expected_past, expected_future, expected_imperative, expected_conditional]
+    a.clear_table()
+    a.conjugate()
+    for tense in range(0, len(v.Tense)):
+        for person in range(0, len(v.Person)):
+            assert expected_conjugations[tense][person] == a.get_conjugation_at(tense, person)
+    assert a.get_table() == expected_conjugations # just double checking!
 
 
+# tests that the right stems are formed and correct conjugations for -át
+def test_class1_at_long_a():
+    a = v.Class1_at("bát", "at")
+
+    # expected conjugations
+    # indices (0-4): present, past, future, imperative, conditional
+    expected_conjugations = []
+    expect_present= ["bám", "báš", "bá", "báme", "báte", "bají"]
+    expected_past = ["bal/a jsem", "bal/a jsi/jseš", "bal/a/o", "bali/y jsme", "bali/y jste", "bali/y/a"]
+    expected_future = ["budu bát", "budeš bát", "bude bát", "budeme bát", "budete bát", "budou bát"]
+    expected_imperative = ["", "bej", "", "bejme", "bejte", ""]
+    expected_conditional = ["bal/a bych", "bal/a bys", "bal/a/o by", "bali/y bychom", "bali/y byste", "bali/y/a by"]
+
+    # from __init__
+    assert a.infinitive == "bát"
+    assert a.ending == "at"
+    assert a.stem == "b"
+    assert a.present_stem == "b"
+    assert a.past_stem == "bal"
+    assert a.imperative_stem == "bej"
+    assert a._is_negative == False
+    assert a._is_perfective == False
+    assert v.get_motion(a._is_motion) == False
+    assert v.get_motion_prefix(a._is_motion) == ""
+
+    # indices (0-4): present, past, future, imperative, conditional
+    expected_conjugations = [expect_present, expected_past, expected_future, expected_imperative, expected_conditional]
+    a.conjugate()
+    for tense in range(0, len(v.Tense)):
+        for person in range(0, len(v.Person)):
+            assert expected_conjugations[tense][person] == a.get_conjugation_at(tense, person)
+    assert a.get_table() == expected_conjugations # just double checking!
+
+
+############# REGULAR CLASS 2 VERBS ###################

--- a/test/test_verbs.py
+++ b/test/test_verbs.py
@@ -568,6 +568,193 @@ def test_class2_ovat():
 
 ###### REGULAR CLASS 3 VERBS #####
 
+# tests conjugation of majority verbs (one's WITHOUT an imperative stem special case)
+
+# regular -it verbs
+def test_class3_it():
+    a = v.Class3_itet("skočit", "it")
+
+    # expected conjugations
+    # indices (0-4): present, past, future, imperative, conditional
+    expected_conjugations = []
+    expect_present= ["skočím", "skočíš", "skočí", "skočíme", "skočíte", "skočí"]
+    expected_past = ["skočil/a jsem", "skočil/a jsi/jseš", "skočil/a/o", "skočili/y jsme", "skočili/y jste", "skočili/y/a"]
+    expected_future = ["budu skočit", "budeš skočit", "bude skočit", "budeme skočit", "budete skočit", "budou skočit"]
+    expected_imperative = ["", "skoč", "", "skočme", "skočte", ""]
+    expected_conditional = ["skočil/a bych", "skočil/a bys", "skočil/a/o by", "skočili/y bychom", "skočili/y byste", "skočili/y/a by"]
+
+    # from __init__
+    assert a.infinitive == "skočit"
+    assert a.ending == "it"
+    assert a.stem == "skoč"
+    assert a.present_stem == "skoč"
+    assert a.past_stem == "skočil"
+    assert a.imperative_stem == "skoč"
+    assert a._is_negative == False
+    assert a._is_perfective == False
+    assert v.get_motion(a._is_motion) == False
+    assert v.get_motion_prefix(a._is_motion) == ""
+
+    # indices (0-4): present, past, future, imperative, conditional
+    expected_conjugations = [expect_present, expected_past, expected_future, expected_imperative, expected_conditional]
+    a.conjugate()
+    for tense in range(0, len(v.Tense)):
+        for person in range(0, len(v.Person)):
+            assert expected_conjugations[tense][person] == a.get_conjugation_at(tense, person)
+    assert a.get_table() == expected_conjugations # just double checking!'
+
+# tests regular -et verbs (hard e, NOT ě!)
+def test_class3_et_hard_e():
+    a = v.Class3_itet("mručet", "et")
+
+    # expected conjugations
+    # indices (0-4): present, past, future, imperative, conditional
+    expected_conjugations = []
+    expect_present= ["mručím", "mručíš", "mručí", "mručíme", "mručíte", "mručí"]
+    expected_past = ["mručel/a jsem", "mručel/a jsi/jseš", "mručel/a/o", "mručeli/y jsme", "mručeli/y jste", "mručeli/y/a"]
+    expected_future = ["budu mručet", "budeš mručet", "bude mručet", "budeme mručet", "budete mručet", "budou mručet"]
+    expected_imperative = ["", "mruč", "", "mručme", "mručte", ""]
+    expected_conditional = ["mručel/a bych", "mručel/a bys", "mručel/a/o by", "mručeli/y bychom", "mručeli/y byste", "mručeli/y/a by"]
+
+    # from __init__
+    assert a.infinitive == "mručet"
+    assert a.ending == "et"
+    assert a.stem == "mruč"
+    assert a.present_stem == "mruč"
+    assert a.past_stem == "mručel"
+    assert a.imperative_stem == "mruč"
+    assert a._is_negative == False
+    assert a._is_perfective == False
+    assert v.get_motion(a._is_motion) == False
+    assert v.get_motion_prefix(a._is_motion) == ""
+
+    # indices (0-4): present, past, future, imperative, conditional
+    expected_conjugations = [expect_present, expected_past, expected_future, expected_imperative, expected_conditional]
+    a.conjugate()
+    for tense in range(0, len(v.Tense)):
+        for person in range(0, len(v.Person)):
+            assert expected_conjugations[tense][person] == a.get_conjugation_at(tense, person)
+    assert a.get_table() == expected_conjugations # just double checking!'
+
+# test regular -ět verbs (soft e)
+def test_class3_et_soft_e():
+    a = v.Class3_itet("dunět", "ět")
+
+    # expected conjugations
+    # indices (0-4): present, past, future, imperative, conditional
+    expected_conjugations = []
+    expect_present= ["duním", "duníš", "duní", "duníme", "duníte", "duní"]
+    expected_past = ["duněl/a jsem", "duněl/a jsi/jseš", "duněl/a/o", "duněli/y jsme", "duněli/y jste", "duněli/y/a"]
+    expected_future = ["budu dunět", "budeš dunět", "bude dunět", "budeme dunět", "budete dunět", "budou dunět"]
+    expected_imperative = ["", "duň", "", "duňme", "duňte", ""]
+    expected_conditional = ["duněl/a bych", "duněl/a bys", "duněl/a/o by", "duněli/y bychom", "duněli/y byste", "duněli/y/a by"]
+
+    # from __init__
+    assert a.infinitive == "dunět"
+    assert a.ending == "ět"
+    assert a.stem == "duň"
+    assert a.present_stem == "dun"
+    assert a.past_stem == "duněl"
+    assert a.imperative_stem == "duň"
+    assert a._is_negative == False
+    assert a._is_perfective == False
+    assert v.get_motion(a._is_motion) == False
+    assert v.get_motion_prefix(a._is_motion) == ""
+
+    # indices (0-4): present, past, future, imperative, conditional
+    expected_conjugations = [expect_present, expected_past, expected_future, expected_imperative, expected_conditional]
+    a.conjugate()
+    for tense in range(0, len(v.Tense)):
+        for person in range(0, len(v.Person)):
+            assert expected_conjugations[tense][person] == a.get_conjugation_at(tense, person)
+    assert a.get_table() == expected_conjugations # just double checking!'
+
+
+# test imperative stem special cases
+def test_class3_imperative_stem_long_et():
+    # verbs to test:
+    # chvět, vyvíjet, vyrábět, umět, přenášet, ztrácet, dovádět, pouštět, zkoušet, prospět, tvářet, slzet
+    assert v.Class3_itet("chvět", "ět").imperative_stem == "chvěj"
+    assert v.Class3_itet("vyvíjet", "et").imperative_stem == "vyvíjej"
+    assert v.Class3_itet("vyrábět", "ět").imperative_stem == "vyráběj"
+    assert v.Class3_itet("umět", "ět").imperative_stem == "uměj"
+    assert v.Class3_itet("přenášet", "et").imperative_stem == "přenášej"
+    assert v.Class3_itet("ztrácet", "et").imperative_stem == "ztrácej"
+    assert v.Class3_itet("dovádět", "ět").imperative_stem == "dováděj"
+    assert v.Class3_itet("pouštět", "ět").imperative_stem == "pouštěj"
+    assert v.Class3_itet("zkoušet", "et").imperative_stem == "zkoušej"
+    assert v.Class3_itet("prospět", "ět").imperative_stem == "prospěj"
+    assert v.Class3_itet("tvářet", "et").imperative_stem == "tvářej"
+    assert v.Class3_itet("slzet", "et").imperative_stem == "slzej"
+
+def test_class3_imperative_stem_long_it():
+    # verbs to test
+    # chýlit, pálit, blížit, bouřit, bránit, cítit, hájit, kamarádit, podřídit, půlit,
+    # rdousit, sloučit, tvářit, úžit, léčit, sílit
+    assert v.Class3_itet("chýlit", "it").imperative_stem == "chyl"
+    assert v.Class3_itet("pálit", "it").imperative_stem == "pal"
+    assert v.Class3_itet("blížit", "it").imperative_stem == "bliž"
+    assert v.Class3_itet("bouřit", "it").imperative_stem == "buř"
+    assert v.Class3_itet("bránit", "it").imperative_stem == "braň"
+    assert v.Class3_itet("cítit", "it").imperative_stem == "ciť"
+    assert v.Class3_itet("hájit", "it").imperative_stem == "haj"
+    assert v.Class3_itet("kamarádit", "it").imperative_stem == "kamaraď"
+    assert v.Class3_itet("podřídit", "it").imperative_stem == "podřiď"
+    assert v.Class3_itet("prýštit", "it").imperative_stem == "prýšti"
+    assert v.Class3_itet("půlit", "it").imperative_stem == "pol"
+    assert v.Class3_itet("rdousit", "it").imperative_stem == "rdus"
+    assert v.Class3_itet("sloučit", "it").imperative_stem == "sluč"
+    assert v.Class3_itet("tvářit", "it").imperative_stem == "tvař"
+    assert v.Class3_itet("úžit", "it").imperative_stem == "už"
+    assert v.Class3_itet("léčit", "it").imperative_stem == "leč"
+    assert v.Class3_itet("sílit", "it").imperative_stem == "sil"
+
+def test_class3_imperative_stem_cluster():
+    # verbs to test
+    # shromáždit, vřeštět, ošetřit, brázdit, ověnčit, bruslit, kreslit, běsnit, hmoždit, čpět, 
+    # patřit, zhoršit, zlepšit, rozluštit, vrstvit, rozmístit, různit, sídlit, svraštit, šustit, tříštit, ústit, prýštit
+
+    assert v.Class3_itet("shromáždit", "it").imperative_stem == "shromáždi"
+    assert v.Class3_itet("vřeštět", "ět").imperative_stem == "vřešti"
+    assert v.Class3_itet("ošetřit", "it").imperative_stem == "ošetři"
+    assert v.Class3_itet("brázdit", "it").imperative_stem == "brázdi"
+    assert v.Class3_itet("ověnčit", "it").imperative_stem == "ověnči"
+    assert v.Class3_itet("bruslit", "it").imperative_stem == "brusli"
+    assert v.Class3_itet("kreslit", "it").imperative_stem == "kresli"
+    assert v.Class3_itet("běsnit", "it").imperative_stem == "běsni"
+    assert v.Class3_itet("hmoždit", "it").imperative_stem == "hmoždi"
+    assert v.Class3_itet("čpět", "ět").imperative_stem == "čpi"
+    assert v.Class3_itet("patřit", "it").imperative_stem == "patři"
+    assert v.Class3_itet("zhoršit", "it").imperative_stem == "zhorši"
+    assert v.Class3_itet("zlepšit", "it").imperative_stem == "zlepši"
+    assert v.Class3_itet("rozluštit", "it").imperative_stem == "rozlušti"
+    assert v.Class3_itet("vrstvit", "it").imperative_stem == "vrstvi"
+    assert v.Class3_itet("rozmístit", "it").imperative_stem == "rozmísti"
+    assert v.Class3_itet("různit", "it").imperative_stem == "různi"
+    assert v.Class3_itet("sídlit", "it").imperative_stem == "sídli"
+    assert v.Class3_itet("svraštit", "it").imperative_stem == "svrašti"
+    assert v.Class3_itet("šustit", "it").imperative_stem == "šusti"
+    assert v.Class3_itet("třístit", "it").imperative_stem == "třísti"
+    assert v.Class3_itet("ústit", "it").imperative_stem == "ústi"
+    assert v.Class3_itet("prýštit", "it").imperative_stem == "prýšti"
+
+def test_class3_imperative_stem():
+    # verbs to test
+    # pršet, trpět, drtit, robit, chytit, zkamenět, oslnit, naplnit, ověřit, mlčet, půjčit, tvrdit, opustit
+    assert v.Class3_itet("pršet", "et").imperative_stem == "prš"
+    assert v.Class3_itet("trpět", "ět").imperative_stem == "trp"
+    assert v.Class3_itet("drtit", "it").imperative_stem == "drť"
+    assert v.Class3_itet("robit", "it").imperative_stem == "rob"
+    assert v.Class3_itet("chytit", "it").imperative_stem == "chyť"
+    assert v.Class3_itet("zkamenět", "ět").imperative_stem == "zkameň"
+    assert v.Class3_itet("oslnit", "it").imperative_stem == "oslň"
+    assert v.Class3_itet("naplnit", "it").imperative_stem == "naplň"
+    assert v.Class3_itet("ověřit", "it").imperative_stem == "ověř"
+    assert v.Class3_itet("mlčet", "et").imperative_stem == "mlč"
+    assert v.Class3_itet("půjčit", "it").imperative_stem == "půjč"
+    assert v.Class3_itet("tvrdit", "it").imperative_stem == "tvrď"
+    assert v.Class3_itet("opustit", "it").imperative_stem == "opusť"
+
 ###### REGULAR CLASS 4 VERBS #####
 
 # tests conjugation of -nout subclass

--- a/test/test_verbs.py
+++ b/test/test_verbs.py
@@ -439,3 +439,298 @@ def test_class1_at_long_a():
 
 
 ############# REGULAR CLASS 2 VERBS ###################
+
+# tests conjugation of the ít/ýt subclass
+def test_class2_yt():
+    a = v.Class2_ityt("být", "ýt")
+
+    # expected conjugations
+    # indices (0-4): present, past, future, imperative, conditional
+    expected_conjugations = []
+    expect_present= ["byji/u", "byješ", "byje", "byjeme", "byjete", "byjí"]
+    expected_past = ["byl/a jsem", "byl/a jsi/jseš", "byl/a/o", "byli/y jsme", "byli/y jste", "byli/y/a"]
+    expected_future = ["budu být", "budeš být", "bude být", "budeme být", "budete být", "budou být"]
+    expected_imperative = ["", "byj", "", "byjme", "byjte", ""]
+    expected_conditional = ["byl/a bych", "byl/a bys", "byl/a/o by", "byli/y bychom", "byli/y byste", "byli/y/a by"]
+
+    # from __init__
+    assert a.infinitive == "být"
+    assert a.ending == "ýt"
+    assert a.stem == "b"
+    assert a.present_stem == "byj"
+    assert a.past_stem == "byl"
+    assert a.imperative_stem == "byj"
+    assert a._is_negative == False
+    assert a._is_perfective == False
+    assert v.get_motion(a._is_motion) == False
+    assert v.get_motion_prefix(a._is_motion) == ""
+
+    # indices (0-4): present, past, future, imperative, conditional
+    expected_conjugations = [expect_present, expected_past, expected_future, expected_imperative, expected_conditional]
+    a.conjugate()
+    for tense in range(0, len(v.Tense)):
+        for person in range(0, len(v.Person)):
+            assert expected_conjugations[tense][person] == a.get_conjugation_at(tense, person)
+    assert a.get_table() == expected_conjugations # just double checking!
+
+def test_class2_it():
+    a = v.Class2_ityt("bít", "ít")
+
+    # expected conjugations
+    # indices (0-4): present, past, future, imperative, conditional
+    expected_conjugations = []
+    expect_present= ["biji/u", "biješ", "bije", "bijeme", "bijete", "bijí"]
+    expected_past = ["bil/a jsem", "bil/a jsi/jseš", "bil/a/o", "bili/y jsme", "bili/y jste", "bili/y/a"]
+    expected_future = ["budu bít", "budeš bít", "bude bít", "budeme bít", "budete bít", "budou bít"]
+    expected_imperative = ["", "bij", "", "bijme", "bijte", ""]
+    expected_conditional = ["bil/a bych", "bil/a bys", "bil/a/o by", "bili/y bychom", "bili/y byste", "bili/y/a by"]
+
+    # from __init__
+    assert a.infinitive == "bít"
+    assert a.ending == "ít"
+    assert a.stem == "b"
+    assert a.present_stem == "bij"
+    assert a.past_stem == "bil"
+    assert a.imperative_stem == "bij"
+    assert a._is_negative == False
+    assert a._is_perfective == False
+    assert v.get_motion(a._is_motion) == False
+    assert v.get_motion_prefix(a._is_motion) == ""
+
+    # indices (0-4): present, past, future, imperative, conditional
+    expected_conjugations = [expect_present, expected_past, expected_future, expected_imperative, expected_conditional]
+    a.conjugate()
+    for tense in range(0, len(v.Tense)):
+        for person in range(0, len(v.Person)):
+            assert expected_conjugations[tense][person] == a.get_conjugation_at(tense, person)
+    assert a.get_table() == expected_conjugations # just double checking!
+
+# tests that the chtít correction is applied on (un)prefixed chtít-like verbs (tests conjugations only affected by correction)
+def test_class2_chtit_correction():
+    a = v.Class2_ityt("chtít", "ít")
+    a.conjugate(v.Tense.PRESENT, v.Person.FIRST_SG)
+    a.conjugate(v.Tense.PRESENT, v.Person.THIRD_PL)
+    assert a.get_conjugation_at(v.Tense.PRESENT, v.Person.FIRST_SG) == "chci"
+    assert a.get_conjugation_at(v.Tense.PRESENT, v.Person.THIRD_PL) == "chtějí"
+
+    b = v.Class2_ityt("nechtít", "ít")
+    b.conjugate(v.Tense.PRESENT, v.Person.FIRST_SG)
+    b.conjugate(v.Tense.PRESENT, v.Person.THIRD_PL)
+    assert b.get_conjugation_at(v.Tense.PRESENT, v.Person.FIRST_SG) == "nechci"
+    assert b.get_conjugation_at(v.Tense.PRESENT, v.Person.THIRD_PL) == "nechtějí"
+
+    c = v.Class2_ityt("zachtít", "ít")
+    c.conjugate(v.Tense.PRESENT, v.Person.FIRST_SG)
+    c.conjugate(v.Tense.PRESENT, v.Person.THIRD_PL)
+    assert c.get_conjugation_at(v.Tense.PRESENT, v.Person.FIRST_SG) == "zachci"
+    assert c.get_conjugation_at(v.Tense.PRESENT, v.Person.THIRD_PL) == "zachtějí"
+
+    d = v.Class2_ityt("nezachtít", "ít")
+    d.conjugate(v.Tense.PRESENT, v.Person.FIRST_SG)
+    d.conjugate(v.Tense.PRESENT, v.Person.THIRD_PL)
+    assert d.get_conjugation_at(v.Tense.PRESENT, v.Person.FIRST_SG) == "nezachci"
+    assert d.get_conjugation_at(v.Tense.PRESENT, v.Person.THIRD_PL) == "nezachtějí"
+
+# tests the conjugation of the ovat subclass
+def test_class2_ovat():
+    a = v.Class2_ovat("bovat", "ovat")
+
+    # expected conjugations
+    # indices (0-4): present, past, future, imperative, conditional
+    expected_conjugations = []
+    expect_present= ["buji/u", "buješ", "buje", "bujeme", "bujete", "bují"]
+    expected_past = ["boval/a jsem", "boval/a jsi/jseš", "boval/a/o", "bovali/y jsme", "bovali/y jste", "bovali/y/a"]
+    expected_future = ["budu bovat", "budeš bovat", "bude bovat", "budeme bovat", "budete bovat", "budou bovat"]
+    expected_imperative = ["", "buj", "", "bujme", "bujte", ""]
+    expected_conditional = ["boval/a bych", "boval/a bys", "boval/a/o by", "bovali/y bychom", "bovali/y byste", "bovali/y/a by"]
+
+    # from __init__
+    assert a.infinitive == "bovat"
+    assert a.ending == "ovat"
+    assert a.stem == "b"
+    assert a.present_stem == "buj"
+    assert a.past_stem == "boval"
+    assert a.imperative_stem == "buj"
+    assert a._is_negative == False
+    assert a._is_perfective == False
+    assert v.get_motion(a._is_motion) == False
+    assert v.get_motion_prefix(a._is_motion) == ""
+
+    # indices (0-4): present, past, future, imperative, conditional
+    expected_conjugations = [expect_present, expected_past, expected_future, expected_imperative, expected_conditional]
+    a.conjugate()
+    for tense in range(0, len(v.Tense)):
+        for person in range(0, len(v.Person)):
+            assert expected_conjugations[tense][person] == a.get_conjugation_at(tense, person)
+    assert a.get_table() == expected_conjugations # just double checking!'
+
+
+
+###### REGULAR CLASS 3 VERBS #####
+
+###### REGULAR CLASS 4 VERBS #####
+
+# tests conjugation of -nout subclass
+def test_class4_nout_with_vowel():
+    a = v.Class4_nout("bnout", "nout")
+
+    # expected conjugations
+    # indices (0-4): present, past, future, imperative, conditional
+    expected_conjugations = []
+    expect_present= ["bnu", "bneš", "bne", "bneme", "bnete", "bnou"]
+    expected_past = ["bnul/a jsem", "bnul/a jsi/jseš", "bnul/a/o", "bnuli/y jsme", "bnuli/y jste", "bnuli/y/a"]
+    expected_future = ["budu bnout", "budeš bnout", "bude bnout", "budeme bnout", "budete bnout", "budou bnout"]
+    expected_imperative = ["", "bni", "", "bněme", "bněte", ""]
+    expected_conditional = ["bnul/a bych", "bnul/a bys", "bnul/a/o by", "bnuli/y bychom", "bnuli/y byste", "bnuli/y/a by"]
+
+    # from __init__
+    assert a.infinitive == "bnout"
+    assert a.ending == "nout"
+    assert a.stem == "b"
+    assert a.present_stem == "bn"
+    assert a.past_stem == "bnul"
+    assert a.imperative_stem == "bni"
+    assert a._is_negative == False
+    assert a._is_perfective == False
+    assert v.get_motion(a._is_motion) == False
+    assert v.get_motion_prefix(a._is_motion) == ""
+
+    # indices (0-4): present, past, future, imperative, conditional
+    expected_conjugations = [expect_present, expected_past, expected_future, expected_imperative, expected_conditional]
+    a.conjugate()
+    for tense in range(0, len(v.Tense)):
+        for person in range(0, len(v.Person)):
+            assert expected_conjugations[tense][person] == a.get_conjugation_at(tense, person)
+    assert a.get_table() == expected_conjugations # just double checking!'
+
+def test_class4_nout_without_vowel():
+    a = v.Class4_nout("benout", "nout")
+
+    # expected conjugations
+    # indices (0-4): present, past, future, imperative, conditional
+    expected_conjugations = []
+    expect_present= ["benu", "beneš", "bene", "beneme", "benete", "benou"]
+    expected_past = ["benul/a jsem", "benul/a jsi/jseš", "benul/a/o", "benuli/y jsme", "benuli/y jste", "benuli/y/a"]
+    expected_future = ["budu benout", "budeš benout", "bude benout", "budeme benout", "budete benout", "budou benout"]
+    expected_imperative = ["", "beň", "", "beňme", "beňte", ""]
+    expected_conditional = ["benul/a bych", "benul/a bys", "benul/a/o by", "benuli/y bychom", "benuli/y byste", "benuli/y/a by"]
+
+    # from __init__
+    assert a.infinitive == "benout"
+    assert a.ending == "nout"
+    assert a.stem == "be"
+    assert a.present_stem == "ben"
+    assert a.past_stem == "benul"
+    assert a.imperative_stem == "beň"
+    assert a._is_negative == False
+    assert a._is_perfective == False
+    assert v.get_motion(a._is_motion) == False
+    assert v.get_motion_prefix(a._is_motion) == ""
+
+    # indices (0-4): present, past, future, imperative, conditional
+    expected_conjugations = [expect_present, expected_past, expected_future, expected_imperative, expected_conditional]
+    a.conjugate()
+    for tense in range(0, len(v.Tense)):
+        for person in range(0, len(v.Person)):
+            assert expected_conjugations[tense][person] == a.get_conjugation_at(tense, person)
+    assert a.get_table() == expected_conjugations # just double checking!'
+
+# tests -st subclass
+def test_class4_st():
+    a = v.Class4_st("bást", "st")
+
+    # expected conjugations
+    # indices (0-4): present, past, future, imperative, conditional
+    expected_conjugations = []
+    expect_present= ["badu", "badeš", "bade", "bademe", "badete", "badou"]
+    expected_past = ["badl/a jsem", "badl/a jsi/jseš", "badl/a/o", "badli/y jsme", "badli/y jste", "badli/y/a"]
+    expected_future = ["budu bást", "budeš bást", "bude bást", "budeme bást", "budete bást", "budou bást"]
+    expected_imperative = ["", "baď", "", "baďme", "baďte", ""]
+    expected_conditional = ["badl/a bych", "badl/a bys", "badl/a/o by", "badli/y bychom", "badli/y byste", "badli/y/a by"]
+
+    # from __init__
+    assert a.infinitive == "bást"
+    assert a.ending == "st"
+    assert a.stem == "ba"
+    assert a.present_stem == "bad"
+    assert a.past_stem == "badl"
+    assert a.imperative_stem == "baď"
+    assert a._is_negative == False
+    assert a._is_perfective == False
+    assert v.get_motion(a._is_motion) == False
+    assert v.get_motion_prefix(a._is_motion) == ""
+
+    # indices (0-4): present, past, future, imperative, conditional
+    expected_conjugations = [expect_present, expected_past, expected_future, expected_imperative, expected_conditional]
+    a.conjugate()
+    for tense in range(0, len(v.Tense)):
+        for person in range(0, len(v.Person)):
+            assert expected_conjugations[tense][person] == a.get_conjugation_at(tense, person)
+    assert a.get_table() == expected_conjugations # just double checking!'
+
+
+# tests conjugation of -zt subclass
+def test_class4_zt():
+    a = v.Class4_zt("bázt", "zt")
+
+    # expected conjugations
+    # indices (0-4): present, past, future, imperative, conditional
+    expected_conjugations = []
+    expect_present= ["bazu", "bazeš", "baze", "bazeme", "bazete", "bazou"]
+    expected_past = ["bazl/a jsem", "bazl/a jsi/jseš", "bazl/a/o", "bazli/y jsme", "bazli/y jste", "bazli/y/a"]
+    expected_future = ["budu bázt", "budeš bázt", "bude bázt", "budeme bázt", "budete bázt", "budou bázt"]
+    expected_imperative = ["", "baz", "", "bazme", "bazte", ""]
+    expected_conditional = ["bazl/a bych", "bazl/a bys", "bazl/a/o by", "bazli/y bychom", "bazli/y byste", "bazli/y/a by"]
+
+    # from __init__
+    assert a.infinitive == "bázt"
+    assert a.ending == "zt"
+    assert a.stem == "ba"
+    assert a.present_stem == "baz"
+    assert a.past_stem == "bazl"
+    assert a.imperative_stem == "baz"
+    assert a._is_negative == False
+    assert a._is_perfective == False
+    assert v.get_motion(a._is_motion) == False
+    assert v.get_motion_prefix(a._is_motion) == ""
+
+    # indices (0-4): present, past, future, imperative, conditional
+    expected_conjugations = [expect_present, expected_past, expected_future, expected_imperative, expected_conditional]
+    a.conjugate()
+    for tense in range(0, len(v.Tense)):
+        for person in range(0, len(v.Person)):
+            assert expected_conjugations[tense][person] == a.get_conjugation_at(tense, person)
+    assert a.get_table() == expected_conjugations # just double checking!
+
+# tests conjugation of -ct subclass
+def test_class4_ct():
+    a = v.Class4_ct("báct", "ct")
+
+    # expected conjugations
+    # indices (0-4): present, past, future, imperative, conditional
+    expected_conjugations = []
+    expect_present= ["baču", "bačeš", "bače", "bačeme", "bačete", "bačou"]
+    expected_past = ["bakl/a jsem", "bakl/a jsi/jseš", "bakl/a/o", "bakli/y jsme", "bakli/y jste", "bakli/y/a"]
+    expected_future = ["budu báct", "budeš báct", "bude báct", "budeme báct", "budete báct", "budou báct"]
+    expected_imperative = ["", "bač", "", "bačme", "bačte", ""]
+    expected_conditional = ["bakl/a bych", "bakl/a bys", "bakl/a/o by", "bakli/y bychom", "bakli/y byste", "bakli/y/a by"]
+
+    # from __init__
+    assert a.infinitive == "báct"
+    assert a.ending == "ct"
+    assert a.stem == "ba"
+    assert a.present_stem == "bač"
+    assert a.past_stem == "bakl"
+    assert a.imperative_stem == "bač"
+    assert a._is_negative == False
+    assert a._is_perfective == False
+    assert v.get_motion(a._is_motion) == False
+    assert v.get_motion_prefix(a._is_motion) == ""
+
+    # indices (0-4): present, past, future, imperative, conditional
+    expected_conjugations = [expect_present, expected_past, expected_future, expected_imperative, expected_conditional]
+    a.conjugate()
+    for tense in range(0, len(v.Tense)):
+        for person in range(0, len(v.Person)):
+            assert expected_conjugations[tense][person] == a.get_conjugation_at(tense, person)
+    assert a.get_table() == expected_conjugations # just double checking!

--- a/test/test_verbs.py
+++ b/test/test_verbs.py
@@ -1,0 +1,323 @@
+# tests verb classes in initialization and conjugation of non-present tenses and non-indicative moods
+
+import pytest
+import src.verbs as v
+
+############# BASE CLASS VERB TESTS ################
+
+# tests initialization of a Verb
+def test_init_default():
+     # test with all empty strings
+     a = v.Verb()
+     assert a.infinitive == ""
+     assert a.ending == ""
+     assert a.stem == ""
+     assert a.present_stem == ""
+     assert a.past_stem == ""
+     assert a.imperative_stem == ""
+
+
+def test_init_non_default():
+    # tests initializations with non-empty strings
+    a = v.Verb("foo", "bar")
+    assert a.infinitive == "foo"
+    assert a.ending == "bar"
+    assert a.stem == ""
+    assert a.present_stem == ""
+    assert a.past_stem == ""
+    assert a.imperative_stem == ""
+
+    # conjugation should also be empty
+    for tense in range(v.Tense.NUM_TENSE):
+        for person in range(v.Person.NUM_PERSON):
+            assert a.get_conjugation_at(tense, person) == ""
+
+
+# test conjugations across each tense
+def test_conjugate_present():
+    # should still remain the empty string
+    a = v.Verb()
+    a.conjugate(v.Tense.PRESENT)
+
+    # including spaces since it's not normally a verb is conjugated with empty strings
+    expected_present= [" ", " ", " ", " ", " ", " "] # present tense is class dependent
+    for person in range(v.Person.NUM_PERSON):
+        assert expected_present[person] == a.get_conjugation_at(v.Tense.PRESENT, person)
+
+    # even with an infinitive should still be empty
+    b = v.Verb("foobar", "bar")
+    b.conjugate(v.Tense.PRESENT)
+    for person in range(v.Person.NUM_PERSON):
+        assert expected_present[person] == b.get_conjugation_at(v.Tense.PRESENT, person)
+
+def test_conjugate_past():
+    # should have the right auxillaries
+    a = v.Verb()
+    a.conjugate(v.Tense.PAST)
+    expected_past = ["/a jsem", "/a jsi/jseš", "/a/o ", "i/y jsme", "i/y jste", "i/y/a "] # past tense
+    for person in range(v.Person.NUM_PERSON):
+        assert expected_past[person] == a.get_conjugation_at(v.Tense.PAST, person)
+
+
+    # auxiliaries should still be correct with non-empty (in this case empty)
+    b = v.Verb("foobar", "bar")
+    b.conjugate(v.Tense.PAST)
+    for person in range(v.Person.NUM_PERSON):
+        assert expected_past[person] == b.get_conjugation_at(v.Tense.PAST, person)
+
+def test_conjugate_future():
+     # should have the right auxillaries
+    a = v.Verb()
+    a.conjugate(v.Tense.FUTURE)
+    expected_future = ["budu ", "budeš ", "bude ", "budeme ", "budete ", "budou "] # future tense
+    for person in range(v.Person.NUM_PERSON):
+        assert expected_future[person] == a.get_conjugation_at(v.Tense.FUTURE, person)
+
+
+    # there should now be an associated infinitive that is non-empty
+    expected_future = ["budu foobar", "budeš foobar", "bude foobar", "budeme foobar", "budete foobar", "budou foobar"] # future tense
+    b = v.Verb("foobar", "bar")
+    b.conjugate(v.Tense.FUTURE)
+    for person in range(v.Person.NUM_PERSON):
+        assert expected_future[person] == b.get_conjugation_at(v.Tense.FUTURE, person)
+
+def test_conjugate_imperative():
+     # should have the right auxillaries
+    a = v.Verb()
+    a.conjugate(v.Tense.IMPERATIVE)
+    expected_imperative = ["", " ", "", "me ", "te ", ""] # imperative mood
+    for person in range(v.Person.NUM_PERSON):
+        assert expected_imperative[person] == a.get_conjugation_at(v.Tense.IMPERATIVE, person)
+
+
+    # should all still be empty-ish
+    b = v.Verb("foobar", "bar")
+    b.conjugate(v.Tense.IMPERATIVE)
+    for person in range(v.Person.NUM_PERSON):
+        assert expected_imperative[person] == b.get_conjugation_at(v.Tense.IMPERATIVE, person)
+
+def test_conjugate_conditional():
+    # should have the right auxillaries
+    expected_conditional = ["/a bych", "/a bys", "/a/o by", "i/y bychom", "i/y byste", "i/y/a by"]
+    a = v.Verb()
+    a.conjugate(v.Tense.CONDITIONAL)
+    for person in range(v.Person.NUM_PERSON):
+        assert expected_conditional[person] == a.get_conjugation_at(v.Tense.CONDITIONAL, person)
+
+
+    # should all still be empty-ish
+    b = v.Verb("foobar", "bar")
+    b.conjugate(v.Tense.CONDITIONAL)
+    for person in range(v.Person.NUM_PERSON):
+        assert expected_conditional[person] == b.get_conjugation_at(v.Tense.CONDITIONAL, person)
+
+
+# test conjugations across all persons (and i guess tests that other entries remain empty)
+def test_conjugate_first_person_singular():
+    # expected conjugations
+    # indices (0-4): present, past, future, imperative, conditional
+    person = v.Person.FIRST_SG
+    expected_conjugations = [" ", "/a jsem", "budu ", "", "/a bych"]
+
+    a = v.Verb()
+    a.conjugate(person_idx = person)
+    for tense in range(v.Tense.NUM_TENSE):
+        assert expected_conjugations[tense] == a.get_conjugation_at(tense, person)
+
+    b = v.Verb("foobar", "bar")
+    expected_conjugations = [" ", "/a jsem", "budu foobar", "", "/a bych"]
+    b.conjugate(person_idx = person)
+    for tense in range(v.Tense.NUM_TENSE):
+        assert expected_conjugations[tense] == b.get_conjugation_at(tense, person)
+
+def test_conjugate_second_person_singular():
+    # expected conjugations
+    # indices (0-4): present, past, future, imperative, conditional
+    person = v.Person.SECOND_SG
+    expected_conjugations = [" ", "/a jsi/jseš", "budeš ", " ", "/a bys"]
+
+    a = v.Verb()
+    a.conjugate(person_idx = person)
+    for tense in range(v.Tense.NUM_TENSE):
+        assert expected_conjugations[tense] == a.get_conjugation_at(tense, person)
+
+    b = v.Verb("foobar", "bar")
+    expected_conjugations = [" ", "/a jsi/jseš", "budeš foobar", " ", "/a bys"]
+    b.conjugate(person_idx = person)
+    for tense in range(v.Tense.NUM_TENSE):
+        assert expected_conjugations[tense] == b.get_conjugation_at(tense, person)
+
+def test_conjugate_third_person_singular():
+    # expected conjugations
+    # indices (0-4): present, past, future, imperative, conditional
+    person = v.Person.THIRD_SG
+    expected_conjugations = [" ", "/a/o ", "bude ", "", "/a/o by"]
+
+    a = v.Verb()
+    a.conjugate(person_idx = person)
+    for tense in range(v.Tense.NUM_TENSE):
+        assert expected_conjugations[tense] == a.get_conjugation_at(tense, person)
+
+    b = v.Verb("foobar", "bar")
+    expected_conjugations = [" ", "/a/o ", "bude foobar", "", "/a/o by"]
+    b.conjugate(person_idx = person)
+    for tense in range(v.Tense.NUM_TENSE):
+        assert expected_conjugations[tense] == b.get_conjugation_at(tense, person)
+
+def test_conjugate_first_person_plural():
+    # expected conjugations
+    # indices (0-4): present, past, future, imperative, conditional
+    person = v.Person.FIRST_PL
+    expected_conjugations = [" ", "i/y jsme", "budeme ", "me ", "i/y bychom"]
+
+    a = v.Verb()
+    a.conjugate(person_idx = person)
+    for tense in range(v.Tense.NUM_TENSE):
+        assert expected_conjugations[tense] == a.get_conjugation_at(tense, person)
+
+    b = v.Verb("foobar", "bar")
+    expected_conjugations = [" ", "i/y jsme", "budeme foobar", "me ", "i/y bychom"]
+    b.conjugate(person_idx = person)
+    for tense in range(v.Tense.NUM_TENSE):
+        assert expected_conjugations[tense] == b.get_conjugation_at(tense, person)
+
+def test_conjugate_second_person_plural():
+    # expected conjugations
+    # indices (0-4): present, past, future, imperative, conditional
+    person = v.Person.SECOND_PL
+    expected_conjugations = [" ", "i/y jste", "budete ", "te ", "i/y byste"]
+
+    a = v.Verb()
+    a.conjugate(person_idx = person)
+    for tense in range(v.Tense.NUM_TENSE):
+        assert expected_conjugations[tense] == a.get_conjugation_at(tense, person)
+
+    b = v.Verb("foobar", "bar")
+    expected_conjugations = [" ", "i/y jste", "budete foobar", "te ", "i/y byste"]
+    b.conjugate(person_idx = person)
+    for tense in range(v.Tense.NUM_TENSE):
+        assert expected_conjugations[tense] == b.get_conjugation_at(tense, person)
+
+def test_conjugate_third_person_plural():
+    # expected conjugations
+    # indices (0-4): present, past, future, imperative, conditional
+    person = v.Person.THIRD_PL
+    expected_conjugations = [" ", "i/y/a ", "budou ", "", "i/y/a by"]
+
+    a = v.Verb()
+    a.conjugate(person_idx = person)
+    for tense in range(v.Tense.NUM_TENSE):
+        assert expected_conjugations[tense] == a.get_conjugation_at(tense, person)
+
+    b = v.Verb("foobar", "bar")
+    expected_conjugations = [" ", "i/y/a ", "budou foobar", "", "i/y/a by"]
+    b.conjugate(person_idx = person)
+    for tense in range(v.Tense.NUM_TENSE):
+        assert expected_conjugations[tense] == b.get_conjugation_at(tense, person)
+
+# test all conjugations at once
+def test_conjugate_all():
+
+    # expected conjugations
+    # indices (0-4): present, past, future, imperative, conditional
+    expected_conjugations = []
+    expected_present= [" ", " ", " ", " ", " ", " "] # present tense is class dependent
+    expected_past = ["/a jsem", "/a jsi/jseš", "/a/o ", "i/y jsme", "i/y jste", "i/y/a "] # past tense
+    expected_future = ["budu ", "budeš ", "bude ", "budeme ", "budete ", "budou "] # future tense
+    expected_imperative = ["", " ", "", "me ", "te ", ""] # imperative mood
+    expected_conditional = ["/a bych", "/a bys", "/a/o by", "i/y bychom", "i/y byste", "i/y/a by"] # (present) conditional mood
+
+    # indices (0-4): present, past, future, imperative, conditional
+    expected_conjugations = [expected_present, expected_past, expected_future, expected_imperative, expected_conditional]
+
+    # conjugate everything
+    a = v.Verb()
+    a.conjugate() 
+    for tense in range(v.Tense.NUM_TENSE):
+        for person in range(v.Person.NUM_PERSON):
+            assert expected_conjugations[tense][person] == a.get_conjugation_at(tense, person)
+
+    # now for a verb with an actual infinitive
+    b = v.Verb("foobar", "bar")
+    expected_future = ["budu foobar", "budeš foobar", "bude foobar", "budeme foobar", "budete foobar", "budou foobar"]
+    expected_conjugations = [expected_present, expected_past, expected_future, expected_imperative, expected_conditional]
+    b.conjugate()
+    for tense in range(v.Tense.NUM_TENSE):
+        for person in range(v.Person.NUM_PERSON):
+            assert expected_conjugations[tense][person] == b.get_conjugation_at(tense, person)
+
+# test clear for one tense (future)
+def test_conjugate_table_clear():
+    tense = v.Tense.FUTURE
+    a = v.Verb()
+    a.conjugate()
+    for person in range(v.Person.NUM_PERSON):
+        assert a.get_conjugation_at(tense, person) != ""
+
+    a.clear_table()
+    for person in range(v.Person.NUM_PERSON):
+        assert a.get_conjugation_at(tense, person) == ""
+
+############# BÝT CLASS TESTS ###############
+def test_byt_stems():
+    byt = v.Byt("být")
+    assert byt.infinitive == "být"
+    assert byt.ending == ""
+    assert byt.stem == ""
+    assert byt.present_stem == ""
+    assert byt.past_stem == "byl"
+    assert byt.imperative_stem == "buď"
+
+    # and the negated form
+    nebyt = v.Byt("nebýt")
+    assert nebyt.infinitive == "nebýt"
+    assert nebyt._is_negative == True
+    assert nebyt._prefix == "ne"
+    assert nebyt.ending == ""
+    assert nebyt.stem == ""
+    assert nebyt.present_stem == ""
+    assert nebyt.past_stem == "nebyl"
+    assert nebyt.imperative_stem == "nebuď"
+
+
+def test_byt_conjugate():
+    byt = v.Byt("být")
+    assert byt._is_negative == False
+    # expected conjugations
+    # indices (0-4): present, past, future, imperative, conditional
+    expected_conjugations = []
+    expected_present= ["jsem", "jseš/jsi", "je", "jsme", "jste", "jsou"]
+    expected_past = ["byl/a jsem", "byl/a jsi/jseš", "byl/a/o ", "byli/y jsme", "byli/y jste", "byli/y/a "]
+    expected_future = ["budu ", "budeš ", "bude ", "budeme ", "budete ", "budou "]
+    expected_imperative = ["", "buď ", "", "buďme ", "buďte ", ""]
+    expected_conditional = ["byl/a bych", "byl/a bys", "byl/a/o by", "byli/y bychom", "byli/y byste", "byli/y/a by"]
+
+    # indices (0-4): present, past, future, imperative, conditional
+    expected_conjugations = [expected_present, expected_past, expected_future, expected_imperative, expected_conditional]
+
+    byt.conjugate()
+    for tense in range(v.Tense.NUM_TENSE):
+        for person in range(v.Person.NUM_PERSON):
+            assert expected_conjugations[tense][person] == byt.get_conjugation_at(tense, person)
+
+def test_nebyt_conjugate():
+    nebyt = v.Byt("nebýt")
+    # expected conjugations
+    # indices (0-4): present, past, future, imperative, conditional
+    expected_conjugations = []
+    expected_present= ["nejsem", "nejseš/jsi", "není", "nejsme", "nejste", "nejsou"]
+    expected_past = ["nebyl/a jsem", "nebyl/a jsi/jseš", "nebyl/a/o ", "nebyli/y jsme", "nebyli/y jste", "nebyli/y/a "]
+    expected_future = ["nebudu ", "nebudeš ", "nebude ", "nebudeme ", "nebudete ", "nebudou "]
+    expected_imperative = ["", "nebuď ", "", "nebuďme ", "nebuďte ", ""]
+    expected_conditional = ["nebyl/a bych", "nebyl/a bys", "nebyl/a/o by", "nebyli/y bychom", "nebyli/y byste", "nebyli/y/a by"]
+
+    # indices (0-4): present, past, future, imperative, conditional
+    expected_conjugations = [expected_present, expected_past, expected_future, expected_imperative, expected_conditional]
+
+    nebyt.conjugate()
+    for tense in range(v.Tense.NUM_TENSE):
+        for person in range(v.Person.NUM_PERSON):
+            assert expected_conjugations[tense][person] == nebyt.get_conjugation_at(tense, person)
+
+
+

--- a/test/test_vutils.py
+++ b/test/test_vutils.py
@@ -17,7 +17,7 @@ def test_get_short_vowel():
              "s", "š", "t", "ť", "u", "ú", "ů", "ou", "v", "w", "x", "y", "ý", "z", "ž"]
     expected = ["a", "a", "b", "c", "č", "d", "ď", "e", "ě", "e", "f", "g", "h", "ch",
              "i", "i", "j", "k", "l", "m", "n", "ň", "o", "ó", "p", "q", "r", "ř",
-             "s", "š", "t", "ť", "u", "ú", "o", "u", "v", "w", "x", "y", "y", "z", "ž"]
+             "s", "š", "t", "ť", "u", "u", "o", "u", "v", "w", "x", "y", "y", "z", "ž"]
     
     for i in range(len(alphabet)):
         assert vutils.get_short_vowel(alphabet[i]) == expected[i]
@@ -110,7 +110,7 @@ def test_get_vowel():
     assert vutils.get_vowel(consonants) == expected
 
      # all vowels
-    expected = "aeiouyáéíóúůýouěií" # repeat since using regex string as source
+    expected = "ouáéíóúůýaeiouyěií" # repeat since using regex string as source
     vowels = vutils.vowel
     assert vutils.get_vowel(vowels) == expected
 
@@ -122,7 +122,7 @@ def test_get_vowel():
 # vowels return empty
 # consonant clusters should be returned properly
 # empty string is obviously empty
-def test_get_consoant():
+def test_get_consonant():
     # test strings will also container other symbols since using regex strings
     # but they are OBVIOUSLY not consonants
 
@@ -136,8 +136,8 @@ def test_get_consoant():
     assert vutils.get_consonant(vowels) == expected
 
      # all vowels
-    expected = "dghknrstbmpvfqwxcčďjlňřšťzžchstštctčt" # repeat since using regex string as source
-    consonants = vutils.consonant
+    expected = "chstštctčtdghknstrbmpvfqwxcčďjňřšťzžl" # repeat since using regex string as source
+    consonants = vutils.consonant_or_digraph
     assert vutils.get_consonant(consonants) == expected
 
     # vowels and consonants
@@ -175,8 +175,6 @@ def test_contains_vowel():
 
 # tests lengthen() function
 # basically test of get_long_vowel() but with words instead of letters
-# CAVEAT: does not work with consonant-final stems
-# CAVEAT: does not work with multiple vowels within stem
 def test_lengthen():
     # nothing
     stem = ""
@@ -195,8 +193,6 @@ def test_lengthen():
 
 # tests shorten() function
 # basically test of get_short_vowel() but with words instead of letters
-# CAVEAT: does not work with consonant-final stems
-# CAVEAT: does not work with multiple vowels within stem
 def test_shorten():
     # nothing
     stem = ""
@@ -208,15 +204,13 @@ def test_shorten():
              "s", "š", "t", "ť", "u", "ú", "ů", "ou", "v", "w", "x", "y", "ý", "z", "ž"]
     expected = ["a", "a", "b", "c", "č", "d", "ď", "e", "ě", "e", "f", "g", "h", "ch",
              "i", "i", "j", "k", "l", "m", "n", "ň", "o", "ó", "p", "q", "r", "ř",
-             "s", "š", "t", "ť", "u", "ú", "o", "u", "v", "w", "x", "y", "y", "z", "ž"]
+             "s", "š", "t", "ť", "u", "u", "o", "u", "v", "w", "x", "y", "y", "z", "ž"]
     
     for i in range(len(alphabet)):
         assert vutils.shorten( "n" + alphabet[i]) == "n" + expected[i]
 
 # tests soften() function
 # basically test of get_soft_consonant() but with words instead of letters
-# CAVEAT: does not work with vowel-final stems
-# CAVEAT: does not work with multiple consonants within stem
 def test_soften():
     # nothing
     stem = ""
@@ -235,8 +229,6 @@ def test_soften():
 
 # tests harden() function
 # basically test of get_hard_consonant() but with words instead of letters
-# CAVEAT: does not work with vowel-final stems
-# CAVEAT: does not work with multiple consonants within stem
 def test_harden():
     # nothing
     stem = ""
@@ -260,12 +252,37 @@ def test_harden():
 def test_fix_spelling():
 
     expected = [["ce", "ci", "cí"], ["če", "či", "čí"], ["dě", "di", "dí"], ["je", "ji", "jí"],
-                ["le", "li", "lí"], ["ně", "ni", "ní"], ["ře", "ři", "ří"], ["še", "ši", "ší"],
-                ["tě", "ti", "tí"], ["ze", "zi", "zí"], ["že", "ži", "ží"]]  
+                ["ně", "ni", "ní"], ["ře", "ři", "ří"], ["še", "ši", "ší"], ["tě", "ti", "tí"], 
+                ["ze", "zi", "zí"], ["že", "ži", "ží"], ["le", "li", "lí"]]  
     for i in range(len(vutils.soft_consonant[1:-1])): # no [] in string
         for j in range(len(vutils.soft_vowel[1:-1])): # no [] in string
             consonant = vutils.soft_consonant[1 + i] # skip [
             vowel = vutils.soft_vowel[1 + j] # skip [
             assert vutils.fix_spelling(consonant + vowel) == expected[i][j]
+
+
+# tests syllables
+def test_syllables():
+
+    s = vutils.Syllables("pokrm")
+    assert s.syllable_list == [('po', False), ('krm', True)]
+    assert s.inspect_syllable(0) == 'po'
+    assert s.inspect_syllable(1) == 'krm'
+    assert s.is_syllabic(0) == False
+    assert s.is_syllabic(1) == True
+
+    s = vutils.Syllables("trp")
+    assert s.syllable_list == [('trp', True)]
+    assert s.inspect_syllable(0) == 'trp'
+    assert s.is_syllabic(0) == True
+
+    s = vutils.Syllables("shromazdit")
+    assert s.syllable_list == [('shro', False), ('ma', False), ('zdit', False)]
+    assert s.inspect_syllable(0) == 'shro'
+    assert s.inspect_syllable(1) == 'ma'
+    assert s.inspect_syllable(2) == 'zdit'
+    assert s.is_syllabic(0) == False
+    assert s.is_syllabic(1) == False
+    assert s.is_syllabic(2) == False
 
 

--- a/test/test_vutils.py
+++ b/test/test_vutils.py
@@ -3,16 +3,6 @@
 import pytest
 import src.verb_utils as vutils
 
-# dummy test
-def test_hello():
-    print("hello world! :)")
-    assert 493 == 493
-
-# dummy test
-def test_goodbye():
-    print("goodbye world! :(")
-    assert 493 == 493
-
 # tests italics() with the empty string 
 def test_italics():
     test_str=""


### PR DESCRIPTION
Refactoring completed of `verbs.py` with testing of it in `test_verbs.py`. Classes were reworked to store the conjugations and endings rather than how it was previously: being generated all at once when `conjugate()` was called (and wholly untestable).

There is still a bug in `verb_utils.py` regarding the `shorten`, `lengthen`, `harden`, `soften` functions, but their is usage is being avoided/limited for the time being. 

Making further progress with #1 
Fixes #2 